### PR TITLE
Change wc to cat in test for portability

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -2596,10 +2596,10 @@
   output:
     output:
       class: File
-      checksum: sha1$2936abd60952276ffbf91d709b19c6c48c263947
+      checksum: sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376
       location: output
-      size: 24
-  tool: tests/wc-tool-shortcut.cwl
+      size: 1111
+  tool: tests/cat-tool-shortcut.cwl
   label: stdin_shorcut
   doc: Test command execution in with stdin and stdout redirection using stdin shortcut
   tags: [ command_line_tool, docker ]

--- a/tests/cat-tool-shortcut.cwl
+++ b/tests/cat-tool-shortcut.cwl
@@ -1,0 +1,20 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+cwlVersion: v1.2.0-dev1
+
+requirements:
+  - class: DockerRequirement
+    dockerPull: debian:stretch-slim
+
+inputs:
+  file1: stdin
+
+outputs:
+  output:
+    type: File
+    outputBinding: { glob: output }
+
+baseCommand: [cat]
+
+stdout: output


### PR DESCRIPTION
Turns out `wc` command output format is not the same in different environments, which leads to different checksum and a failed test. I couldn't trace the root cause of the difference, it was the same command line in the same docker image, with the same environment variables inside the image but a slightly different format was created.