### PR TITLE
Clarify behavior of Dirent.entry for all allowed values

### DIFF
--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -942,7 +942,7 @@ $graph:
         designated output directory prior to executing the command line tool.
 
         May be an expression. If so, the expression return value must validate as
-        `{type: array, items: ["null", File, File[], Directory, Directory[], Dirent]}`.
+        `{type: array, items: ["null", File, Directory, Dirent, {type: array, items: [File, Directory]}]}`.
 
         Files or Directories which are listed in the input parameters and
         appear in the `InitialWorkDirRequirement` listing must have their

--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -874,13 +874,21 @@ $graph:
         If the value is a string literal or an expression which evaluates to a
         string, a new file must be created with the string as the file contents.
 
-        If the value is an expression that evaluates to a `File` object, this
-        indicates the referenced file should be added to the designated output
-        directory prior to executing the tool.
+        If the value is an expression that evaluates to a `File` or `Directory` 
+        object, this indicates the referenced file or directory should be added 
+        to the designated output directory prior to executing the tool.
+
+        If the value is an expression that evaluates to an array of `File` or 
+        `Directory` objects, this indicates the referenced files or directories 
+        should be added to the designated output directory prior to executing 
+        the tool, with ignoring the value in `entryname`.
 
         If the value is an expression that evaluates to a `Dirent` object, this
         indicates that the File or Directory in `entry` should be added to the
         designated output directory with the name in `entryname`.
+
+        If the value is an expression that evaluates to `null`, nothing is added
+        to the designated output directory from this entry.
 
         If `writable` is false, the file may be made available using a bind
         mount or file system link to avoid unnecessary copying of the input


### PR DESCRIPTION
In v1.1 we expanded the set of allowed values to `null` and `array<File|Dir>`, bit it was not explicitly documented in the Dirent.entry doc, which might cause confusion to implementers (it already confused one developer which is why this PR was made :) )