### PR TITLE
Rename only_non_null pickValue method

### DIFF
--- a/Workflow.yml
+++ b/Workflow.yml
@@ -181,7 +181,7 @@ $graph:
     Picking non-null values among inbound data links, described in [WorkflowStepInput](#WorkflowStepInput).
   symbols:
     - first_non_null
-    - only_non_null
+    - exactly_one_non_null
     - all_non_null
 
 
@@ -354,7 +354,7 @@ $graph:
       fallback value. The conditional step(s) should be placed first in
       the list.
 
-    * **only_non_null**
+    * **exactly_one_non_null**
 
       For the first level of a list input, pick the single non-null element.  The result is a scalar.
       It is an error if there is more than one non-null element.  Examples:

--- a/Workflow.yml
+++ b/Workflow.yml
@@ -181,7 +181,7 @@ $graph:
     Picking non-null values among inbound data links, described in [WorkflowStepInput](#WorkflowStepInput).
   symbols:
     - first_non_null
-    - exactly_one_non_null
+    - the_only_non_null
     - all_non_null
 
 
@@ -354,7 +354,7 @@ $graph:
       fallback value. The conditional step(s) should be placed first in
       the list.
 
-    * **exactly_one_non_null**
+    * **the_only_non_null**
 
       For the first level of a list input, pick the single non-null element.  The result is a scalar.
       It is an error if there is more than one non-null element.  Examples:


### PR DESCRIPTION
Opened this PR mainly for discussion on if we should rename the method and what the new name should be. Reason for the rename request is that the behavior of this method is not intuitive (at least it wasn't for me when I implemented these, as initially I though only_non_null returns all non null values). 
I also did a small experiment where I listed the pickValue method names to three colleagues and asked them which method does what. All three of them couldn't figure out what would be the difference between `only_non_null` and `all_non_null`.
In the PR the proposed name is `exactly_one_non_null`, I was thinking also maybe `the_only_non_null`.
 @kaushik-work @mr-c @tetron happy to hear your thoughts on this. I guess we can discuss on the meeting tuesday