### PR TITLE
Test/initworkdir

### DIFF
--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -886,7 +886,7 @@ $graph:
         If the value is an expression that evaluates to an array of `File` or
         `Directory` objects, this indicates the referenced files or directories
         should be added to the designated output directory prior to executing
-        the tool, with ignoring the value in `entryname`.
+        the tool.
 
         If the value is an expression that evaluates to a `Dirent` object, this
         indicates that the File or Directory in `entry` should be added to the

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -2891,7 +2891,7 @@
         "location": "lsout",
         "size": 32
       }
-  tags: [ resource, command_line_tool ]
+  tags: [ resource, command_line_tool, initial_work_dir ]
   id: 225
 
 - job: tests/stage-array-dirs-job.yml
@@ -2913,7 +2913,7 @@
             }
         ]
     }
-  tags: [ resource, command_line_tool ]
+  tags: [ resource, command_line_tool, initial_work_dir ]
   id: 226
 
 - job: tests/env-job3.yaml
@@ -3102,7 +3102,7 @@
           "size": 59
         }
       ]
-  tags: [ required, command_line_tool ]
+  tags: [ required, command_line_tool, initial_work_dir ]
   id: 238
 
 - doc: Test that array of input files can be staged to directory with basename
@@ -3137,7 +3137,7 @@
           "size": 59
         }
       ]
-  tags: [ required, command_line_tool ]
+  tags: [ required, command_line_tool, initial_work_dir ]
   id: 239
 
 - doc: Test that if array of input files are staged to directory with basename and entryname, entryname overrides
@@ -3172,7 +3172,7 @@
           "size": 59
         }
       ]
-  tags: [ required, command_line_tool ]
+  tags: [ required, command_line_tool, initial_work_dir ]
   id: 240
 
 - job: tests/empty.json

--- a/tests/stage-array.cwl
+++ b/tests/stage-array.cwl
@@ -27,6 +27,7 @@ requirements:
       - $(inputs.input_file)
       - $(inputs.optional_file)
       - entry: $(inputs.input_list)
+      - entry: $(null)
       - entryname: a
         entry: b
   - class: ShellCommandRequirement


### PR DESCRIPTION
Add a specific test case where `entry` returns null (there was already a case where a lone expression in initworkdir returns null, this one was missing). Also, add tags to conformance_tests.yaml and update docs for `entry` (remove a wrong information I previously added).