### PR TITLE
Fix up missing/duplicate labels and missing tags (1/n)

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -327,7 +327,7 @@
   output:
     count_output: 16
   tool: tests/count-lines19-wf.cwl
-  label: wf_wc_nomultiple
+  label: wf_wc_nomultiple_merge_nested
   id: count-lines19-wf
   doc: >-
     Test when step source is a single-item list and linkMerge is
@@ -2986,10 +2986,13 @@
       "class": "File"
       "size": 12010
   tool: tests/initialworkdir-glob-fullpath.cwl
-  doc: Test output of InitialWorkDir
+  label: initial_workdir_output_glob
+  doc: Test full path glob output of InitialWorkDir
   tags: [ initial_work_dir, command_line_tool ]
   id: 230
 
+# same test as above but keeping it for preserve ids maybe? I don't know -
+# there is a reason I added labels before these ids were here :)
 - job: tests/initialworkdirrequirement-docker-out-job.json
   output:
     OUTPUT:
@@ -3004,15 +3007,17 @@
       "class": "File"
       "size": 12010
   tool: tests/initialworkdir-glob-fullpath.cwl
-  doc: Test if full paths are allowed in glob
-  tags: [ initial_work_dir ]
+  label: initial_workdir_output_glob_duplicate
+  doc: Test full path glob output of InitialWorkDir (duplicate)
+  tags: [ initial_work_dir, command_line_tool ]
   id: 231
 
 - job: tests/empty.json
   should_fail: true
   tool: tests/glob-path-error.cwl
+  label: glob_outside_outputs_fails
   doc: Test fail trying to glob outside output directory
-  tags: [ required ]
+  tags: [ required, command_line_tool, docker ]
   id: 232
 
 - job: tests/empty.json
@@ -3160,7 +3165,7 @@
   id: 239
 
 - doc: Test that if array of input files are staged to directory with basename and entryname, entryname overrides
-  label: stage_file_array
+  label: stage_file_array_entryname_overrides
   tool: tests/stage_file_array_basename_and_entryname.cwl
   job: tests/stage_file_array.job.json
   output:

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -879,7 +879,7 @@
   label: metadata
   id: 63
   doc: Test metadata
-  tags: [ required ]
+  tags: [ required, command_line_tool ]
 
 - job: tests/formattest-job.json
   output:
@@ -1894,7 +1894,7 @@
        checksum: "sha1$7d5ca8c0c03e883c56c4eb1ef6f6bb9bccad4d86"
        size: 8
   tool: tests/envvar3.cwl
-  label: env_home_tmpdir_docker
+  label: env_home_tmpdir_docker_no_return_code
   id: 134
   doc: Test $HOME and $TMPDIR are set correctly in Docker without using return code
   tags: [ shell_command, command_line_tool ]
@@ -2894,7 +2894,7 @@
   tool: tests/networkaccess2.cwl
   label: networkaccess_disabled
   doc: Test networkaccess is disabled by default
-  tags: [ networkaccess ]
+  tags: [ networkaccess, command_line_tool ]
   id: 224
 
 - job: tests/stage-array-job.json
@@ -2987,7 +2987,7 @@
       "size": 12010
   tool: tests/initialworkdir-glob-fullpath.cwl
   doc: Test output of InitialWorkDir
-  tags: [ initial_work_dir ]
+  tags: [ initial_work_dir, command_line_tool ]
   id: 230
 
 - job: tests/initialworkdirrequirement-docker-out-job.json
@@ -3025,6 +3025,7 @@
       "baesname": "symlink.txt"
       "checksum": "sha1$cd28ec34f3f9425aca544b6332453708e8aaa82a"
   should_fail: true
+  tags: [ command_line_tool ]
   id: 233
 
 - job: tests/empty.json
@@ -3037,11 +3038,12 @@
       "basename": "symlink.txt"
       "checksum": "sha1$cd28ec34f3f9425aca544b6332453708e8aaa82a"
   id: 234
+  tags: [ command_line_tool ]
 
 - job: tests/empty.json
   tool: tests/inp_update_wf.cwl
   doc: inplace update has side effect on file content
-  tags: [ inplace_update ]
+  tags: [ inplace_update, workflow ]
   output:
     a: 4
     b: 4
@@ -3050,7 +3052,7 @@
 - job: tests/empty.json
   tool: tests/inpdir_update_wf.cwl
   doc: inplace update has side effect on directory content
-  tags: [ inplace_update ]
+  tags: [ inplace_update, workflow ]
   output: {
     a: [
             {


### PR DESCRIPTION
Brings in https://github.com/common-workflow-language/cwl-v1.1/pull/72/files and starts to work on new CWL 1.2 tests.

I don't know what to do about the duplicate test below - the tests (230, 231) had different labels and tags but they were the same test. A copy-paste problem I assume? Because of the ``id``s, it will break the ordering to just remove it so I just appending _duplicate to the new label for the second one.

I guess we don't promise the ordering of ``id`` doesn't have holes- should I just remove it?