### PR TITLE
Fix broken test workflows re: issue #51

### DIFF
--- a/tests/timelimit-wf.cwl
+++ b/tests/timelimit-wf.cwl
@@ -30,5 +30,5 @@ steps:
         o:
           type: string?
           outputBinding:
-            outputEval: "time passed"
+            outputEval: $(runtime.outdir)
       

--- a/tests/timelimit4-wf.cwl
+++ b/tests/timelimit4-wf.cwl
@@ -33,4 +33,4 @@ steps:
         o:
           type: string?
           outputBinding:
-            outputEval: $(runtime.outdir)
+            outputEval: $("time passed")

--- a/tests/timelimit4-wf.cwl
+++ b/tests/timelimit4-wf.cwl
@@ -33,4 +33,4 @@ steps:
         o:
           type: string?
           outputBinding:
-            outputEval: "time passed"
+            outputEval: $(runtime.outdir)


### PR DESCRIPTION
As per issue https://github.com/common-workflow-language/cwl-v1.2/issues/51 the two workflows used in the  `timelimit_from_expression_wf` and `timelimit_basic_wf` tests have syntax errors. This PR fixes #51 