### PR TITLE
Update run test.sh

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -132,8 +132,8 @@ runtest() {
 
     runs=$((runs+1))
     (COMMAND="cwltest --tool $1 \
-	     --test=conformance_tests.yaml ${CLASS} ${TEST_N} \
-	     ${VERBOSE} ${TEST_L} ${TEST_J} ${ONLY_TOOLS} ${JUNIT_XML} \
+         --test=conformance_tests.yaml ${CLASS} ${TEST_N} \
+         ${VERBOSE} ${TEST_L} ${TEST_J} ${ONLY_TOOLS} ${JUNIT_XML} \
          ${TIMEOUT} ${BADGE} ${TAGS} -- ${EXTRA}"
      if [ "$VERBOSE" = "--verbose" ]; then echo "${COMMAND}"; fi
      ${COMMAND}

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-read -rd "\000" helpmessage <<EOF
-$(basename $0): Run common workflow tool description language conformance tests.
+func() {
+	helpmessage=$(cat)
+}
+func <<EOF
+$(basename "$0"): Run common workflow tool description language conformance tests.
 
 Syntax:
-        $(basename $0) [RUNNER=/path/to/cwl-runner]
+        $(basename "$0") [RUNNER=/path/to/cwl-runner] [DRAFT=cwl-draft-version]
                        [EXTRA=--optional-arguments-to-cwl-runner]
 
 Options:
@@ -17,24 +20,33 @@ Options:
                         FILENAME
   --classname=CLASSNAME In the JUnit XML, tag the results with the given
                         CLASSNAME
+  --timeout=TIMEOUT     cwltest timeout in seconds.
   --verbose             Print the cwltest invocation and pass --verbose to
                         cwltest
+  --self                Test CWL and test .cwl files themselves. If this flag
+                        is given, any other flags will be ignored.
+  --badgedir=DIRNAME    Specifies the directory to store JSON files for badges.
+  --tags TAGS           Tags to be tested
 
 Note:
   EXTRA is useful for passing --enable-dev to the CWL reference runner:
   Example: RUNNER=cwltool EXTRA=--enable-dev
 EOF
 
+CWL_VER=v1.2
 TEST_N=""
 JUNIT_XML=""
 RUNNER=cwl-runner
 PLATFORM=$(uname -s)
-COVERAGE="python"
 EXTRA=""
 CLASS=""
 VERBOSE=""
+SELF=""
+BADGE=""
+TIMEOUT=""
+TAGS=""
 
-while [[ -n "$1" ]]
+while [ -n "$1" ]
 do
     arg="$1"; shift
     case "$arg" in
@@ -64,13 +76,40 @@ do
         --verbose)
             VERBOSE=$arg
             ;;
+        --self)
+            SELF=1
+            ;;
+        --badgedir=*)
+            BADGE=$arg
+            ;;
+        --timeout=*)
+            TIMEOUT=$arg
+            ;;
+        --tags=*)
+            TAGS=$arg
+            ;;
         *=*)
-            eval $(echo $arg | cut -d= -f1)=\"$(echo $arg | cut -d= -f2-)\"
+            eval "$(echo "$arg" | cut -d= -f1)"=\""$(echo "$arg" | cut -d= -f2-)"\"
             ;;
     esac
 done
 
-if ! runner="$(which $RUNNER)" ; then
+if [ -n "${SELF}" ]; then
+    # Ensure schema-salad-tool command
+    if [ ! -x "$(command -v schema-salad-tool)" ]; then
+        pip install --quiet schema_salad
+    fi
+    # This is how CWL should be written.
+    DEFINITION=./CommonWorkflowLanguage.yml
+    # Let's test each files
+    for target in $(find tests -type f -name "*.cwl"); do
+        schema-salad-tool ${DEFINITION} "${target}" --quiet
+        if [[ $? -ne 0 ]]; then echo "[INVALID] ${target}" && exit 1; fi
+    done
+    exit 0
+fi
+
+if ! runner="$(command -v $RUNNER)" ; then
     echo >&2 "$helpmessage"
     echo >&2
     echo >&2 "runner '$RUNNER' not found"
@@ -81,13 +120,13 @@ runs=0
 failures=0
 
 checkexit() {
-    if [[ "$?" != "0" ]]; then
+    if [ "$?" != "0" ]; then
         failures=$((failures+1))
     fi
 }
 
 runtest() {
-    echo "--- Running CWL Conformance Tests on $1 ---"
+    echo "--- Running CWL Conformance Tests $CWL_VER on $1 ---"
 
     "$1" --version
 
@@ -95,25 +134,37 @@ runtest() {
     (COMMAND="cwltest --tool $1 \
 	     --test=conformance_tests.yaml ${CLASS} ${TEST_N} \
 	     ${VERBOSE} ${TEST_L} ${TEST_J} ${ONLY_TOOLS} ${JUNIT_XML} \
-	     -- ${EXTRA}"
-     if [[ $VERBOSE == "--verbose" ]]; then echo ${COMMAND}; fi
+         ${TIMEOUT} ${BADGE} ${TAGS} -- ${EXTRA}"
+     if [ "$VERBOSE" = "--verbose" ]; then echo "${COMMAND}"; fi
      ${COMMAND}
     )
     checkexit
 }
 
-if [[ $PLATFORM == "Linux" ]]; then
-    runtest "$(readlink -f $runner)"
+if [ "$PLATFORM" = "Linux" ]; then
+    runtest "$(readlink -f "$runner")"
 else
-    runtest "$(greadlink -f $runner)"
+    runtest "$(greadlink -f "$runner")"
 fi
 
-if [[ -n "$TEST_L" ]] ; then
+if [ -n "$TEST_L" ] ; then
    exit 0
 fi
 
 # Final reporting
 
 echo
+
+if [ $failures != 0 ]; then
+    echo "$failures tool tests failed"
+else
+    if [ $runs = 0 ]; then
+        echo >&2 "$helpmessage"
+        echo >&2
+        exit 1
+    else
+        echo "All tool tests succeeded"
+    fi
+fi
 
 exit $failures

--- a/run_test.sh
+++ b/run_test.sh
@@ -7,7 +7,7 @@ func <<EOF
 $(basename "$0"): Run common workflow tool description language conformance tests.
 
 Syntax:
-        $(basename "$0") [RUNNER=/path/to/cwl-runner] [DRAFT=cwl-draft-version]
+        $(basename "$0") [RUNNER=/path/to/cwl-runner]
                        [EXTRA=--optional-arguments-to-cwl-runner]
 
 Options:


### PR DESCRIPTION
This request fixes #70.

Basically it copies `run_test.sh` in [common-workflow-language/common-workflow-language](https://github.com/common-workflow-language/common-workflow-language) but includes several minor changes:

- delete `DRAFT` stuff
- introduce `CWL_VER` but only used in the message in `runtest` function
- fix `--self` to check `tests` directory recursively

I confirmed that `--timeout` (only positive cases), `--self` (checked it recursively validates the documents), `--badgedir` and `--tags` work correctly.
