### PR TITLE
Add CI settings for Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.x'
+      
+      - name: Setup prerequirements
+        run: pip install cwltest schema-salad
+      
+      - name: Download schema for conformance_tests.yaml
+        run: curl -LO https://raw.githubusercontent.com/common-workflow-language/cwltest/main/cwltest/cwltest-schema.yml
+      
+      - name: Validate conformance_tests.yaml
+        run: schema-salad-tool cwltest-schema.yml conformance_tests.yaml
+      
+      - name: Validate CWL documents
+        run: ./run_test.sh --self


### PR DESCRIPTION
This request adds `.github/workflows/ci.yml`.

It validates:
- `conformance_tests.yaml` using `cwltest-schema.yml`
  - Note: CI downloads the schema from the following link. Please let me know if there is more appropriate link for the schema.
    - https://raw.githubusercontent.com/common-workflow-language/cwltest/main/cwltest/cwltest-schema.yml
- all the CWL documents in `tests` directory
