### PR TITLE
Clarify InitialWorkDirRequirement.writable

### DIFF
--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -979,7 +979,7 @@ $graph:
         implemented by making a copy of the original file or
         directory.
 
-        Desruptive changes to the referenced file or directory must not
+        Disruptive changes to the referenced file or directory must not
         be allowed unless `InplaceUpdateRequirement.inplaceUpdate` is true.
 
         Default false (files and directories read-only by default).

--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -979,6 +979,9 @@ $graph:
         implemented by making a copy of the original file or
         directory.
 
+        Desruptive changes to the referenced file or directory must not
+        be allowed unless `InplaceUpdateRequirement.inplaceUpdate` is true.
+
         Default false (files and directories read-only by default).
 
         A directory marked as `writable: true` implies that all files and


### PR DESCRIPTION
This request fixes #82 by clalifying disruptive changes are not allowed without `inplaceUpdate: true`.
