### PR TITLE
Add test to ensure a synthetic file is created properly.

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3379,6 +3379,21 @@
   tags: [ resource, command_line_tool ]
   id: 256
 
+- job: tests/synth-file-job.yml
+  tool: tests/synth-file.cwl
+  label: cat_synthetic_file
+  doc: Test the generation of a synthetic file with inline contents.
+  output:
+    sequence: {
+      "basename": "684051cefdffc63ea1be04442fe133c803d86cbe",
+      "nameext": "",
+      "class": "File",
+      "checksum": "sha1$5d64b71392b1e00a3ad893db02d381d58262c2d6",
+      "size": 7
+    }
+  tags: [ required ]
+  id: 257
+
 - $import: tests/string-interpolation/test-index.yaml
 
 - $import: tests/conditionals/test-index.yaml

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3385,8 +3385,6 @@
   doc: Test the generation of a synthetic file with inline contents.
   output:
     sequence: {
-      "basename": "684051cefdffc63ea1be04442fe133c803d86cbe",
-      "nameext": "",
       "class": "File",
       "checksum": "sha1$5d64b71392b1e00a3ad893db02d381d58262c2d6",
       "size": 7

--- a/tests/synth-file-job.yml
+++ b/tests/synth-file-job.yml
@@ -1,0 +1,4 @@
+names:
+  class: File
+  contents: |
+    random

--- a/tests/synth-file.cwl
+++ b/tests/synth-file.cwl
@@ -1,0 +1,14 @@
+cwlVersion: v1.0
+class: CommandLineTool
+
+inputs:
+  names:
+    type: File
+    inputBinding:
+      position: 1
+
+baseCommand: [ cat ]
+
+outputs:
+  sequence:
+    type: stdout

--- a/tests/synth-file.cwl
+++ b/tests/synth-file.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 
 inputs:


### PR DESCRIPTION
Adds a basic test to check that a file generated with inline contents exists and has the expected contents (using `cat`).

Based on https://github.com/common-workflow-language/cwltool/issues/369 .
