### PR TITLE
InitialWorkDirRequirement tests label/id fix

### DIFF
--- a/tests/iwd/test-index.yaml
+++ b/tests/iwd/test-index.yaml
@@ -1,5 +1,6 @@
 - job: null
-  id: iwd-nolimit
+  id: iwd-1
+  label: iwd-nolimit
   tool: iwd-nolimit.cwl
   output:
    "filelist": {
@@ -13,7 +14,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: null
-  id: iwd-jsondump1
+  id: iwd-2
+  label: iwd-jsondump1
   tool: iwd-jsondump1.cwl
   output:
     "filelist": {
@@ -27,7 +29,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: null
-  id: iwd-jsondump1-nl
+  id: iwd-3
+  label: iwd-jsondump1-nl
   tool: iwd-jsondump1-nl.cwl
   output:
     "filelist": {
@@ -41,7 +44,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: null
-  id: iwd-jsondump2
+  id: iwd-4
+  label: iwd-jsondump2
   tool: iwd-jsondump2.cwl
   output:
     "filelist": {
@@ -55,7 +59,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: null
-  id: iwd-jsondump2-nl
+  id: iwd-5
+  label: iwd-jsondump2-nl
   tool: iwd-jsondump2-nl.cwl
   output:
     "filelist": {
@@ -69,7 +74,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: null
-  id: iwd-jsondump3
+  id: iwd-6
+  label: iwd-jsondump3
   tool: iwd-jsondump3.cwl
   output:
     "filelist": {
@@ -83,7 +89,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: null
-  id: iwd-jsondump3-nl
+  id: iwd-7
+  label: iwd-jsondump3-nl
   tool: iwd-jsondump3-nl.cwl
   output:
     "filelist": {
@@ -97,7 +104,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: ../loadContents/input.yml
-  id: iwd-passthrough1
+  id: iwd-8
+  label: iwd-passthrough1
   tool: iwd-passthrough1.cwl
   output:
     "filelist": {
@@ -111,7 +119,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: ../loadContents/input.yml
-  id: iwd-passthrough2
+  id: iwd-9
+  label: iwd-passthrough2
   tool: iwd-passthrough2.cwl
   output:
     "out": {
@@ -125,7 +134,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: ../loadContents/input.yml
-  id: iwd-passthrough3
+  id: iwd-10
+  label: iwd-passthrough3
   tool: iwd-passthrough3.cwl
   output:
     "filelist": {
@@ -139,7 +149,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: ../loadContents/input.yml
-  id: iwd-passthrough4
+  id: iwd-11
+  label: iwd-passthrough4
   tool: iwd-passthrough4.cwl
   output:
     "filelist": {
@@ -153,7 +164,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: null
-  id: iwd-fileobjs1
+  id: iwd-12
+  label: iwd-fileobjs1
   tool: iwd-fileobjs1.cwl
   output:
     "filelist": {
@@ -202,7 +214,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: null
-  id: iwd-fileobjs2
+  id: iwd-13
+  label: iwd-fileobjs2
   tool: iwd-fileobjs2.cwl
   output:
     "filelist": {
@@ -251,7 +264,8 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: ../loadContents/input.yml
-  id: iwd-container-entryname1
+  id: iwd-14
+  label: iwd-container-entryname1
   tool: iwd-container-entryname1.cwl
   output:
     "head": {
@@ -265,28 +279,32 @@
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: ../loadContents/input.yml
-  id: iwd-container-entryname2
+  id: iwd-15
+  label: iwd-container-entryname2
   tool: iwd-container-entryname2.cwl
   should_fail: true
   doc: "Test input mount locations when no container (should fail)"
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: ../loadContents/input.yml
-  id: iwd-container-entryname3
+  id: iwd-16
+  label: iwd-container-entryname3
   tool: iwd-container-entryname3.cwl
   should_fail: true
   doc: "Test input mount locations when container is a hint (should fail)"
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: ../loadContents/input.yml
-  id: iwd-container-entryname4
+  id: iwd-17
+  label: iwd-container-entryname4
   tool: iwd-container-entryname4.cwl
   should_fail: true
   doc: "Must fail if entryname starts with ../"
   tags: [ initial_work_dir, command_line_tool ]
 
 - job: ../loadContents/input.yml
-  id: iwdr_dir_literal_real_file
+  id: iwd-18
+  label: iwdr_dir_literal_real_file
   tool: iwdr_dir_literal_real_file.cwl
   doc: "Test directory literal containing a real file"
   output:


### PR DESCRIPTION
The tests in `tests/iwd` didn't have labels so could not be filtered by name. I have converted the id to labels and given them ids in the same style as other subdirs of tests (à la conditionals)

When this merges, the conformance tests should pass in CI.
