### PR TITLE
Fix run_test.sh to run on Mac (Darwin)

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -156,6 +156,8 @@ runtest() {
 
 if [ "$PLATFORM" = "Linux" ]; then
     runtest "$(readlink -f "$runner")"
+elif [ "$PLATFORM" = "Darwin" ]; then
+	runtest $runner
 else
     runtest "$(greadlink -f "$runner")"
 fi


### PR DESCRIPTION
When following directions here, https://www.commonwl.org/v1.2/, to execute the test script, run_test.sh fails on Mac (Darwin):
```
$ ./run_test.sh 
./run_test.sh: line 160: greadlink: command not found
--- Running CWL Conformance Tests v1.2 on  ---
./run_test.sh: line 144: : command not found
usage: cwltest [-h] --test TEST [--basedir BASEDIR] [-l] [-n N] [-s S] [-N N]
               [-S S] [--tool TOOL] [--only-tools] [--tags TAGS] [--show-tags]
               [--junit-xml JUNIT_XML] [--junit-verbose]
               [--test-arg cache==--cache-dir] [-j J] [--verbose]
               [--classname CLASSNAME] [--timeout TIMEOUT]
               [--badgedir BADGEDIR] [--version]
               ...
cwltest: error: argument --tool: expected one argument

1 tool tests failed
```

When I run the script with 'bash -ex', the if statement resolves to '[' Darwin = Linux ']':
```
+ '[' Darwin = Linux ']'
++ greadlink -f /Users/golharr/workspace/CWL/env/bin/cwl-runner
./run_test.sh: line 160: greadlink: command not found
```
