### PR TITLE
fix cwloutput-nolimit test's outputs to match the cwl.output.json results 

### DIFF
--- a/tests/loadContents/cwloutput-nolimit.cwl
+++ b/tests/loadContents/cwloutput-nolimit.cwl
@@ -10,4 +10,5 @@ inputs:
     default: {class: File, location: mkfilelist.py}
 outputs:
   filelist: string[]
+  bigstring: string
 arguments: [python, $(inputs.script)]


### PR DESCRIPTION
Which makes this conformance test less mean

Fixes #120