### PR TITLE
Clarify $() and ${}

### DIFF
--- a/concepts.md
+++ b/concepts.md
@@ -602,17 +602,21 @@ requirement `InlineJavascriptRequirement`.  Expressions may be used in any
 field permitting the pseudo-type `Expression`, as specified by this
 document.
 
-Expressions are denoted by the syntax `$(...)` or `${...}`.  A code
-fragment wrapped in the `$(...)` syntax must be evaluated as a
-[ECMAScript expression](http://www.ecma-international.org/ecma-262/5.1/#sec-11).  A
-code fragment wrapped in the `${...}` syntax must be evaluated as a
+Expressions are denoted by the syntax `$(...)` or `${...}`.
+
+A code fragment wrapped in the `$(...)` syntax must be evaluated as a
+[ECMAScript expression](http://www.ecma-international.org/ecma-262/5.1/#sec-11).
+
+A code fragment wrapped in the `${...}` syntax must be evaluated as a
 [ECMAScript function body](http://www.ecma-international.org/ecma-262/5.1/#sec-13)
-for an anonymous, zero-argument function.  Expressions must return a valid JSON
-data type: one of null, string, number, boolean, array, object. Other return
-values must result in a `permanentFailure`. Implementations must permit any
-syntactically valid Javascript and account for nesting of parenthesis or braces
-and that strings that may contain parenthesis or braces when scanning for
-expressions.
+for an anonymous, zero-argument function.  This means the code will be
+evaluated as `(function() { ... })()`.
+
+Expressions must return a valid JSON data type: one of null, string, number,
+boolean, array, object. Other return values must result in a
+`permanentFailure`.  Implementations must permit any syntactically valid
+Javascript and account for nesting of parenthesis or braces and that strings
+that may contain parenthesis or braces when scanning for expressions.
 
 The runtime must include any code defined in the ["expressionLib" field of
 InlineJavascriptRequirement](#InlineJavascriptRequirement) prior to


### PR DESCRIPTION
Fixes https://github.com/common-workflow-language/common-workflow-language/issues/206

Supersedes https://github.com/common-workflow-language/common-workflow-language/pull/929

Quoting the superseded PR:

>Hi,
>
>Having a go at the Barn Raising issue about ES expression and ES function body. At first I wrote a longer version with an example `$(new Date())` for expression, and a longer `${var dt = new Date(); dt.setDate(dt.getDate() - 2); return dt}` function body that returns a date minus 2 days.
>
>But I think it became too specific and made the section even longer? I also thought that perhaps the comparison could go into a NOTE section, but didn't find any such section nearby, so went with the simpler approach.
>
>Happy to amend as per feedback :+1: 
>
>Thanks
>Bruno
>
>~p.s.: this PR also fixes a typo, "EMACScript" where it should be "ECMAScript".~