### PR TITLE
Test for colon in paths

### DIFF
--- a/Process.yml
+++ b/Process.yml
@@ -70,8 +70,8 @@ $graph:
     a number of properties that provide metadata about the file.
 
     The `location` property of a File is a URI that uniquely identifies the
-    file.  Implementations must support the file:// URI scheme and may support
-    other schemes such as http://.  The value of `location` may also be a
+    file.  Implementations must support the `file://` URI scheme and may support
+    other schemes such as `http://` and `https://`.  The value of `location` may also be a
     relative reference, in which case it must be resolved relative to the URI
     of the document it appears in.  Alternately to `location`, implementations
     must also accept the `path` property on File, which must be a filesystem

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3432,3 +3432,38 @@
   label: directory_literal_with_literal_file_in_subdir_nostdin
   doc: Test non-stdin reference to literal File via a nested Directory literal
   tags: [ command_line_tool, required ]
+
+- label: colon_in_paths
+  output:
+    log:
+      class: File
+      basename: re:sult
+      checksum: sha1$d7d6491030bfa0ce17bab3a648e603f2a55bf503
+      size: 14
+    result:
+      class: Directory
+      basename: A:Gln2Cys_result
+      listing:
+        - basename: A:Gln2Cys
+          checksum: sha1$2928c9c6fa02098aee8c31bf44099f3bf8c91013
+          class: File
+          size: 18
+  job: tests/colon:test:job.yaml
+  tool: tests/colon:test.cwl
+  doc: Confirm that colons are tolerated in input paths, string values, stdout shortcut, and output file & directory names
+  tags: [ required, command_line_tool ]
+
+- label: colon_in_output_path
+  output:
+    result:
+      class: Directory
+      basename: A:Gln2Cys_result
+      listing:
+        - basename: hello.txt
+          checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
+          class: File
+          size: 13
+  job: tests/colon_test_output_job.yaml
+  tool: tests/colon_test_output.cwl
+  doc: Confirm that colons are tolerated in output directory names
+  tags: [ required, command_line_tool ]

--- a/tests/A:Gln2Cys
+++ b/tests/A:Gln2Cys
@@ -1,0 +1,1 @@
+Example gene file

--- a/tests/colon:test.cwl
+++ b/tests/colon:test.cwl
@@ -1,0 +1,23 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.2
+hints:
+  DockerRequirement:
+    dockerPull: docker.io/bash:4.4
+inputs:
+  input_file: File
+  outdir_name: string
+
+baseCommand: [ bash, -c ]
+stdout: re:sult
+arguments:
+ - |
+   mkdir $(inputs.outdir_name);
+   cp $(inputs.input_file.path) $(inputs.outdir_name)/;
+   echo Status: done!
+outputs:
+  log: stdout
+  result:
+    type: Directory
+    outputBinding:
+      glob: $(inputs.outdir_name)

--- a/tests/colon:test:job.yaml
+++ b/tests/colon:test:job.yaml
@@ -1,0 +1,6 @@
+input_file:
+ class: File
+ location: A%3AGln2Cys  # location is a URI, even if it is relative,
+                        # so it needs URI encoding
+                        # (also known as percent escaping)
+outdir_name: A:Gln2Cys_result

--- a/tests/colon_test_output.cwl
+++ b/tests/colon_test_output.cwl
@@ -1,0 +1,20 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.2
+hints:
+  DockerRequirement:
+    dockerPull: docker.io/bash:4.4
+inputs:
+  input_file: File
+  outdir_name: string
+
+baseCommand: [ bash, -c ]
+arguments:
+ - |
+   mkdir $(inputs.outdir_name);
+   cp $(inputs.input_file.path) $(inputs.outdir_name)/;
+outputs:
+  result:
+    type: Directory
+    outputBinding:
+      glob: $(inputs.outdir_name)

--- a/tests/colon_test_output_job.yaml
+++ b/tests/colon_test_output_job.yaml
@@ -1,0 +1,4 @@
+input_file:
+ class: File
+ path: hello.txt
+outdir_name: A:Gln2Cys_result


### PR DESCRIPTION
Currently, `cwltool` is too conservative and it does not permit pathnames with `:` (the colon) without the flag `--relax-path-checks`

While the CWL standards do allow for excluding some characters in pathnames, the colon is not one of them:

https://www.commonwl.org/v1.2/CommandLineTool.html#File
under `path`:

> If the `path` contains [POSIX shell metacharacters](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_02) (`|`, `&`, `;`, `<`, `>`, `(`, `)`, `$`, `` ` ``, `\`, `"`, `'`, `<space>`, `<tab>`, and `<newline>`) or characters not allowed for [Internationalized Domain Names for Applications](https://tools.ietf.org/html/rfc6452) then implementations may terminate the process with a `permanentFailure`.

(The text is the same in CWL v1.0 and v1.1)