### PR TITLE
Remove duplicate test

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -2991,27 +2991,6 @@
   tags: [ initial_work_dir, command_line_tool ]
   id: 230
 
-# same test as above but keeping it for preserve ids maybe? I don't know -
-# there is a reason I added labels before these ids were here :)
-- job: tests/initialworkdirrequirement-docker-out-job.json
-  output:
-    OUTPUT:
-      "checksum": "sha1$aeb3d11bdf536511649129f4077d5cda6a324118"
-      "location": "ref.fasta"
-      "secondaryFiles": [{
-        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
-        "location": "ref.fasta.fai",
-          "class": "File",
-          "size": 0
-      }]
-      "class": "File"
-      "size": 12010
-  tool: tests/initialworkdir-glob-fullpath.cwl
-  label: initial_workdir_output_glob_duplicate
-  doc: Test full path glob output of InitialWorkDir (duplicate)
-  tags: [ initial_work_dir, command_line_tool ]
-  id: 231
-
 - job: tests/empty.json
   should_fail: true
   tool: tests/glob-path-error.cwl


### PR DESCRIPTION
Part of #54

Confirmed the IDs are not sequential, as we have missing numbers in between tests. Also checked the schema salad in cwltest, and it allows for `null`s. I think there's some work in cwltest to deprecate ids and use labels - https://github.com/common-workflow-language/cwltest/issues/110

![image](https://user-images.githubusercontent.com/304786/166193035-446a513a-9a5d-4b0c-88bb-32393f106edc.png)

So I believe we can safely remove the duplicate test, as long as CI doesn't complain :crossed_fingers: 