### PR TITLE
Fix a few typos (automatic IDE spellchecker)

### DIFF
--- a/concepts.md
+++ b/concepts.md
@@ -61,7 +61,7 @@ the CWL specification.
 ## Data concepts
 
 An **object** is a data structure equivalent to the "object" type in JSON,
-consisting of a unordered set of name/value pairs (referred to here as
+consisting of an unordered set of name/value pairs (referred to here as
 **fields**) and where the name is a string and the value is a string, number,
 boolean, array, or object.
 
@@ -105,7 +105,7 @@ changed between versions, for that portion of the execution an
 implementation must provide runtime enviroment and behavior consistent
 with the document's declared version.  An implementation must not
 expose a newer feature when executing a document that specifies an
-older version that does not not include that feature.
+older version that does not include that feature.
 
 ### map
 
@@ -115,7 +115,7 @@ Note: This section is non-normative.
 
 The above syntax in the CWL specifications means there are two or more ways to write the given value.
 
-Option one is a array and is the most verbose option.
+Option one is an array and is the most verbose option.
 
 Option one generic example:
 ```
@@ -421,7 +421,7 @@ of [process requirements](#Requirements_and_hints).
 ## Generic execution process
 
 The generic execution sequence of a CWL process (including workflows
-and command line line tools) is as follows.  Processes are
+and command line tools) is as follows.  Processes are
 modeled as functions that consume an input object and produce an
 output object.
 

--- a/invocation.md
+++ b/invocation.md
@@ -3,7 +3,7 @@
 To accommodate the enormous variety in syntax and semantics for input, runtime
 environment, invocation, and output of arbitrary programs, a CommandLineTool
 defines an "input binding" that describes how to translate abstract input
-parameters to an concrete program invocation, and an "output binding" that
+parameters to a concrete program invocation, and an "output binding" that
 describes how to generate output parameters from program output.
 
 ## Input binding

--- a/salad/schema_salad/metaschema/salad.md
+++ b/salad/schema_salad/metaschema/salad.md
@@ -72,7 +72,7 @@ documentation.
 
 ## Introduction to v1.1
 
-This is the third version of of the Schema Salad specification.  It is
+This is the third version of the Schema Salad specification.  It is
 developed concurrently with v1.1 of the Common Workflow Language for use in
 specifying the Common Workflow Language, however Schema Salad is intended to be
 useful to a broader audience.  Compared to the v1.0 schema salad
@@ -113,7 +113,7 @@ the behavior of conforming implementations.
 
 The terminology used to describe Salad documents is defined in the Concepts
 section of the specification. The terms defined in the following list are
-used in building those definitions and in describing the actions of an
+used in building those definitions and in describing the actions of a
 Salad implementation:
 
 **may**: Conforming Salad documents and Salad implementations are permitted but
@@ -139,7 +139,7 @@ enable or disable the behavior described.
 ## Data concepts
 
 An **object** is a data structure equivalent to the "object" type in JSON,
-consisting of a unordered set of name/value pairs (referred to here as
+consisting of an unordered set of name/value pairs (referred to here as
 **fields**) and where the name is a string and the value is a string, number,
 boolean, array, or object.
 
@@ -257,14 +257,14 @@ rules:
 
 ## Document traversal
 
-To perform document document preprocessing, link validation and schema
+To perform document preprocessing, link validation and schema
 validation, the document must be traversed starting from the fields or
 array items of the root object or array and recursively visiting each child
 item which contains an object or arrays.
 
 ## Short names
 
-The "short name" of an fully qualified identifier is the portion of
+The "short name" of a fully qualified identifier is the portion of
 the identifier following the final slash `/` of either the fragment
 identifier following `#` or the path portion, if there is no fragment.
 Some examples:


### PR DESCRIPTION
Cloning more repositories, importing code into a new IDE workspace, and running local linters as part of #54 . Found a few typos in the spec with the WebStorm spell checker inspection. Not sure about those `an` vs. `a`, so happy to amend the PR if needed :+1: 

Thanks!
Bruno