### PR TITLE
Add conformance test that verifies we can use runtime outdir with output glob

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3501,3 +3501,34 @@
     Use of expression tool to change basename of file, then correctly staging
     the file using the new name.
   tags: [ required, command_line_tool, inline_javascript, expression_tool ]
+
+- label: runtime-outdir
+  output: {
+    "stuff": {
+      "class": "Directory",
+      "listing": [
+        {
+          "basename": "baz.txt",
+          "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "class": "File",
+          "size": 0
+        },
+        {
+          "basename": "foo",
+          "class": "Directory",
+          "listing": [
+            {
+              "basename": "bar.txt",
+              "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+              "class": "File",
+              "size": 0
+            }
+          ]
+        }
+      ]
+    }
+  }
+  tool: tests/runtime-outdir.cwl
+  doc: |
+    Use of $(runtime.outdir) for outputBinding glob.
+  tags: [ required, command_line_tool ]

--- a/tests/runtime-outdir.cwl
+++ b/tests/runtime-outdir.cwl
@@ -1,0 +1,14 @@
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: [bash, -c]
+arguments:
+  - |
+    mkdir -p foo
+    touch baz.txt
+    touch foo/bar.txt
+inputs: []
+outputs:
+  stuff:
+    type: Directory
+    outputBinding:
+      glob: $(runtime.outdir)


### PR DESCRIPTION
Closes #109 

First time writing a conformance test for 1.2.1 :tada: 

After installing dependencies and learning how to use `run_tests.sh`, looked at the example in the issue and at existing tests to create this simple test.

Let me know if there are any mistakes, or good practices that I haven't used. I'm looking at the easy issues for now to learn how to write conformance tests.

Thanks!
Bruno