### PR TITLE
Add test for SchemaDefRequirement with a workflow and the types containing an $import statement

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3562,3 +3562,14 @@
     and capture the output correctly.
   tags: [ shell_command, command_line_tool ]
   
+- tool: tests/schemadef_types_with_import-wf.cwl
+  job: tests/schemadef_types_with_import-job.json
+  output: {
+    "out": "1970-01-01T00:00:00Z\n"
+  }
+  label: schemadef_types_with_import
+  doc: >-
+    Test SchemaDefRequirement with a workflow, with the `$import` under types.
+    It is similar to schemadef-wf, but the `$import` is different.
+  tags: [ workflow, schema_def ]
+

--- a/tests/schemadef_types_with_import-job.json
+++ b/tests/schemadef_types_with_import-job.json
@@ -1,0 +1,22 @@
+{
+    "readgroups_bam":
+    {
+        "bam": {
+            "class": "File",
+            "format": "edam:format_2572",
+            "location": "schemadef_types_with_import-test.bam"
+        },
+        "readgroup_meta_list":
+        [
+            {
+                "CN": "UNKNOWN",
+                "DT": "1970-01-01T00:00:00Z",
+                "ID": "SRR622461",
+                "LB": "Illumina NA12878",
+                "PI": "250",
+                "PL": "ILLUMINA",
+                "SM": "NA12878"
+            }
+        ]
+    }
+}

--- a/tests/schemadef_types_with_import-tool.cwl
+++ b/tests/schemadef_types_with_import-tool.cwl
@@ -1,0 +1,26 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.2
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: SchemaDefRequirement
+    types:
+      - $import: schemadef_types_with_import_readgroup.yml
+
+inputs:
+    - id: message
+      type: "schemadef_types_with_import_readgroup.yml#readgroups_bam_file"
+      inputBinding:
+        valueFrom: $(self.readgroup_meta_list[0]['DT'])
+
+outputs:
+    - id: out
+      type: string
+      outputBinding:
+        glob: output.txt
+        loadContents: true
+        outputEval: $(self[0].contents)
+
+stdout: output.txt
+baseCommand: echo

--- a/tests/schemadef_types_with_import-wf.cwl
+++ b/tests/schemadef_types_with_import-wf.cwl
@@ -1,0 +1,25 @@
+#!/usr/bin/env cwl-runner
+# See https://github.com/jeremiahsavage/cwl_schemadef/, thanks to Jeremiah H. Savage.
+cwlVersion: v1.2
+class: Workflow
+
+requirements:
+  - class: SchemaDefRequirement
+    types:
+      - $import: schemadef_types_with_import_readgroup.yml
+
+inputs:
+  readgroups_bam:
+    type: "schemadef_types_with_import_readgroup.yml#readgroups_bam_file"
+
+steps:
+  step1:
+    run: schemadef_types_with_import-tool.cwl
+    in:
+      message: readgroups_bam
+    out: [out]
+
+outputs:
+  out:
+    type: string
+    outputSource: step1/out

--- a/tests/schemadef_types_with_import_readgroup.yml
+++ b/tests/schemadef_types_with_import_readgroup.yml
@@ -1,0 +1,27 @@
+- name: readgroup_meta
+  type: record
+  fields:
+    - name: CN
+      type: string
+    - name: DT
+      type: string
+    - name: ID
+      type: string
+    - name: LB
+      type: string
+    - name: PI
+      type: string
+    - name: PL
+      type: string
+    - name: SM
+      type: string
+
+- name: readgroups_bam_file
+  type: record
+  fields:
+    - name: bam
+      type: File
+    - name: readgroup_meta_list
+      type:
+        type: array
+        items: readgroup_meta


### PR DESCRIPTION
For https://github.com/common-workflow-language/common-workflow-language/issues/703

Used example written by @jeremiahsavage (thanks!). It doesn't output anything, but validates that it could import the types successfully.

Or if we prefer to test for some output, I can rewrite it to output something.

Cheers
Bruno
