### PR TITLE
Add extra description of `run` field

### DIFF
--- a/Workflow.yml
+++ b/Workflow.yml
@@ -619,7 +619,8 @@ $graph:
         _type: "@id"
         subscope: run
       doc: |
-        Specifies the process to run.
+        Specifies the process to run.  If `run` is a string, it must be an absolute IRI
+        or a relative path from the primary document.
     - name: when
       type:
         - "null"


### PR DESCRIPTION
This request is to solve [common-workflow-language/common-worflow-language#760](https://github.com/common-workflow-language/common-workflow-language/issues/760) by adding the description of the case of `string`.