### PR TITLE
Mention that we can refer to workflow level inputs in output parameter outputSource

### DIFF
--- a/Workflow.yml
+++ b/Workflow.yml
@@ -225,8 +225,11 @@ $graph:
   fields:
     - name: outputSource
       doc: |
-        Specifies one or more workflow parameters that supply the value of to
-        the output parameter.
+        Specifies one or more names of an output from a workflow step (in the form 
+        `step_name/output_name` with a `/` separator`), or a workflow input name,
+        that supply their value(s) to the output parameter.
+        the output parameter.  It is valid to reference workflow level inputs
+        here.
       jsonldPredicate:
         "_id": "cwl:outputSource"
         "_type": "@id"

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3540,3 +3540,11 @@
   doc: |
     Use of $(runtime.outdir) for outputBinding glob.
   tags: [ required, command_line_tool ]
+- label: output_reference_workflow_input
+  output: {
+    "last": "me"
+  }
+  tool: tests/output_reference_workflow_input.cwl
+  doc: |
+    Direct use of Workflow level input fields in the outputs.
+  tags: [ required, workflow ]

--- a/tests/output_reference_workflow_input.cwl
+++ b/tests/output_reference_workflow_input.cwl
@@ -1,0 +1,14 @@
+cwlVersion: v1.2
+class: Workflow
+
+inputs:
+  first:
+    type: string
+    default: me
+
+steps: []
+
+outputs:
+  last:
+   type: string
+   outputSource: first


### PR DESCRIPTION
Closes https://github.com/common-workflow-language/common-workflow-language/issues/763

Not sure if an example would be useful (haven't seen other examples). Or maybe better to leave the specification simpler and add details in the user guide.