### PR TITLE
Update the doc and use "true" as base command for the metadata test

### DIFF
--- a/tests/metadata.cwl
+++ b/tests/metadata.cwl
@@ -8,7 +8,7 @@ $schemas:
 
 cwlVersion: v1.2
 class: CommandLineTool
-doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
+doc: "Test that a command line document with metadata is executed successfully."
 
 dct:creator:
   id: "http://orcid.org/0000-0003-3566-7705"
@@ -19,14 +19,6 @@ dct:creator:
 hints:
   DockerRequirement:
     dockerPull: docker.io/debian:stable-slim
-inputs:
-  file1:
-    type: File
-    inputBinding: {position: 1}
-  numbering:
-    type: boolean?
-    inputBinding:
-      position: 0
-      prefix: -n
+inputs: []
 outputs: []
-baseCommand: cat
+baseCommand: "true"


### PR DESCRIPTION
Was thinking about https://github.com/common-workflow-language/common-workflow-language/issues/743, and my initial thought was to use the output of `--pack metadata.cwl` which would include the metadata. But couldn't figure out a way to reference that in the test output (tried to think in a way to use some JS expression for that, but I don't think the metadata is loaded in the JS expr context.)

So I went with the other alternative mentioned in the issue, updating the test documentation to show the intention of testing the metadata. I think the previous doc could be misleading, making the reader think it was about printing the output of `cat` and maybe using it in the test…

Or maybe there's some better way to update that test?