### PR TITLE
Remove stray backtick in the docs

### DIFF
--- a/concepts.md
+++ b/concepts.md
@@ -191,7 +191,7 @@ hints:
         version: [ "1.0" ]
       python: {}
 ```
-`
+
 Sometimes we have a third and even more compact option denoted like this:
 > type: array&lt;ComplexType&gt; |
 > map&lt;`key_field`, `field2` | ComplexType&gt;


### PR DESCRIPTION
Found when I was re-generating the conformance HTML in schema salad for https://github.com/common-workflow-language/schema_salad/pull/543