### PR TITLE
Add new test for chained commands, update the specification wording

### DIFF
--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -567,6 +567,10 @@ $graph:
     stdout: random_stdout_filenameABCDEFG
     ```
 
+    If the `CommandLineTool` contains logically chained commands
+    (e.g. `echo a && echo b`) `stdout` must include the output of
+    every command.
+
 
 - name: stderr
   type: enum
@@ -699,6 +703,10 @@ $graph:
       doc: |
         Capture the command's standard output stream to a file written to
         the designated output directory.
+
+        If the `CommandLineTool` contains logically chained commands
+        (e.g. `echo a && echo b`) `stdout` must include the output of
+        every command.
 
         If `stdout` is a string, it specifies the file name to use.
 
@@ -1105,8 +1113,8 @@ $graph:
   extends: ProcessRequirement
   doc: |
     Modify the behavior of CommandLineTool to generate a single string
-    containing a shell command line.  Each item in the argument list must be
-    joined into a string separated by single spaces and quoted to prevent
+    containing a shell command line.  Each item in the `arguments` list must
+    be joined into a string separated by single spaces and quoted to prevent
     intepretation by the shell, unless `CommandLineBinding` for that argument
     contains `shellQuote: false`.  If `shellQuote: false` is specified, the
     argument is joined into the command string without quoting, which allows

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3540,3 +3540,16 @@
   doc: |
     Use of $(runtime.outdir) for outputBinding glob.
   tags: [ required, command_line_tool ]
+
+- label: stdout_chained_commands
+  output: {
+    "out": "a\nb\n"
+  }
+  tool: tests/stdout_chained_commands.cwl
+  doc: |
+    Test that chaining two echo calls causes the workflow tool to emit the output to stdout.
+    This is to confirm that the workflow tool will **not** create an expression such as
+    `echo a && echo b > out.txt`, but instead will produce the correct `echo a && echo b`,
+    and capture the output correctly.
+  tags: [ shell_command, command_line_tool ]
+

--- a/invocation.md
+++ b/invocation.md
@@ -132,7 +132,11 @@ Once the command line is built and the runtime environment is created, the
 actual tool is executed.
 
 The standard error stream and standard output stream may be captured by
-platform logging facilities for storage and reporting.
+platform logging facilities for storage and reporting.  If there are multiple
+commands logically chained (e.g. `echo a && echo b`) implementations must
+capture the output of all the commands, and not only the output of the last
+command (i.e. the following is incorrect `echo a && echo b > captured`,
+as the output of `echo a` is not included in `captured`).
 
 Tools may be multithreaded or spawn child processes; however, when the
 parent process exits, the tool is considered finished regardless of whether

--- a/tests/stdout_chained_commands.cwl
+++ b/tests/stdout_chained_commands.cwl
@@ -1,0 +1,19 @@
+cwlVersion: v1.2
+class: CommandLineTool
+requirements:
+  - class: ShellCommandRequirement
+inputs: []
+outputs:
+  out:
+    type: string
+    outputBinding:
+      glob: out.txt
+      loadContents: true
+      outputEval: $(self[0].contents)
+stdout: out.txt
+arguments:
+  - echo
+  - a
+  - {valueFrom: '&&', shellQuote: false}
+  - echo
+  - b


### PR DESCRIPTION
Closes #95 

Hadn't used `ShellCommandRequirement` yet, it looks useful!

Added a new conformance test, and tried to update the spec. I noticed that text is often repeated in the specification, which I find useful, so I did the same here. The docs for `stdout` received the same text, but I tried to explain a little better at the Execution section for running the tool.

Cheers
-Bruno