### PR TITLE
Added Conformance Test for Optional Record #886

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3378,3 +3378,9 @@
     Test SchemaDefRequirement with a workflow, with the `$import` under types.
     It is similar to schemadef-wf, but the `$import` is different.
   tags: [ workflow, schema_def ]
+
+- tool: tests/optional_record.cwl
+  job: tests/optional-record.yaml 
+  doc: Test where a record describes one of the inputs and the input itself(optional) but if it is present then all fields of the record must be provided.
+  tags: [ command_line_tool ]
+  

--- a/tests/optional-record.yaml
+++ b/tests/optional-record.yaml
@@ -1,0 +1,3 @@
+input: 
+  one : "Test for first input"
+  two: ""

--- a/tests/optional_record.cwl
+++ b/tests/optional_record.cwl
@@ -1,0 +1,26 @@
+class: CommandLineTool
+cwlVersion: v1.2
+doc: "Describes one of the inputs and the input itself is optional. However,
+      if it is there then all parts of the input (all fields in the record) must be there"
+baseCommand:
+  - echo
+inputs:
+  one:
+    type:
+      - 'null'
+      - type: record
+        fields:
+          - name: one
+            type: string
+            inputBinding:
+              position: 1
+          - name: two
+            type: string
+            inputBinding:
+              position: 2
+  two:
+    type: string
+outputs:
+  output_one:
+    type: stdout
+stdout: output.txt


### PR DESCRIPTION
This Draft PR is in relation to: [link](https://cwl.discourse.group/t/how-can-i-expression-an-optional-record-with-required-fields/49/2) . 

I followed the thread and tried to replicate it but I still want clarity on the inputs for the test.

I also validated the test which I saw in the docs: 
`afimaamedufie@Afis-MacBook-Pro tests % cwl-runner --validate optional_record.cwl
INFO /Users/afimaamedufie/.pyenv/versions/3.10.2/bin/cwl-runner 3.1.20221018083734
INFO Resolved 'optional_record.cwl' to 'file:///Users/afimaamedufie/cwl/cwl-v1.2/tests/optional_record.cwl'
optional_record.cwl is valid CWL.`

However, I get an error I don't quite get in relation to the inputs:

`afimaamedufie@Afis-MacBook-Pro tests % cwl-runner optional_record.cwl
INFO /Users/afimaamedufie/.pyenv/versions/3.10.2/bin/cwl-runner 3.1.20221018083734
INFO Resolved 'optional_record.cwl' to 'file:///Users/afimaamedufie/cwl/cwl-v1.2/tests/optional_record.cwl'
usage: optional_record.cwl [-h] [--one.one ONE.ONE] [--one.two ONE.TWO] --two TWO [job_order]
optional_record.cwl: error: the following arguments are required: --two`

Any help @mr-c ?
