### PR TITLE
fix over-indented list interpreted as code + typo (must be replace[d])

### DIFF
--- a/salad/schema_salad/metaschema/vocab_res.yml
+++ b/salad/schema_salad/metaschema/vocab_res.yml
@@ -1,16 +1,16 @@
 - |
   ## Vocabulary resolution
 
-    The schema may designate one or more vocabulary fields which use
-    terms defined in the vocabulary.  The vocabulary are the short
-    names of all the identifiers in the schema.  Processing must
-    resolve vocabulary fields to either vocabulary terms or absolute
-    URIs by first applying the link resolution rules defined above,
-    then applying the following additional rule:
+  The schema may designate one or more vocabulary fields which use
+  terms defined in the vocabulary.  The vocabulary are the short
+  names of all the identifiers in the schema.  Processing must
+  resolve vocabulary fields to either vocabulary terms or absolute
+  URIs by first applying the link resolution rules defined above,
+  then applying the following additional rule:
 
-      * If a reference URI is a vocabulary field, and there is a vocabulary
-      term which maps to the resolved URI, the reference must be replace with
-      the vocabulary term.
+  * If a reference URI is a vocabulary field, and there is a vocabulary
+    term which maps to the resolved URI, the reference must be replaced with
+    the vocabulary term.
 
   ### Vocabulary resolution example
 


### PR DESCRIPTION
Before
https://www.commonwl.org/v1.2/SchemaSalad.html#Vocabulary_resolution
![image](https://user-images.githubusercontent.com/19194484/200100178-b5f42c06-2fed-468d-866f-d2e6adffd1a6.png)

After
![image](https://user-images.githubusercontent.com/19194484/200100186-c3f05711-8e00-4df7-9e3e-1ced1619ab5a.png)

