### PR TITLE
add code format to parameter references table definitions 

### DIFF
--- a/concepts.md
+++ b/concepts.md
@@ -491,21 +491,45 @@ references use the following subset of
 syntax, but they are designed to not require a Javascript engine for evaluation.
 
 In the following [BNF grammar](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_Form),
-character classes and grammar rules are denoted in '{}', '-' denotes
-exclusion from a character class, '(())' denotes grouping, '|' denotes
-alternates, trailing '*' denotes zero or more repeats, '+' denote one
+character classes and grammar rules are denoted in `{}`, `-` denotes
+exclusion from a character class, `(())` denotes grouping, `|` denotes
+alternates, trailing `*` denotes zero or more repeats, `+` denotes one
 or more repeats, and all other characters are literal values.
 
-<p>
+<div>
 <table class="table">
-<tr><td>symbol::             </td><td>{Unicode alphanumeric}+</td></tr>
-<tr><td>singleq::            </td><td>[' (( {character - { | \ ' \} } ))* ']</td></tr>
-<tr><td>doubleq::            </td><td>[" (( {character - { | \ " \} } ))* "]</td></tr>
-<tr><td>index::              </td><td>[ {decimal digit}+ ]</td></tr>
-<tr><td>segment::            </td><td>. {symbol} | {singleq} | {doubleq} | {index}</td></tr>
-<tr><td>parameter reference::</td><td>$( {symbol} {segment}*)</td></tr>
+<tr>
+    <td><code>symbol</code></td>
+    <td><code>::=</code></td>
+    <td><code>{Unicode alphanumeric}+</code></td>
+</tr>
+<tr>
+    <td><code>singleq</code></td>
+    <td><code>::=</code></td>
+    <td><code>[' (( {character - { | \ ' \} } ))* ']</code></td>
+</tr>
+<tr>
+    <td><code>doubleq</code></td>
+    <td><code>::=</code></td>
+    <td><code>[" (( {character - { | \ " \} } ))* "]</code></td>
+</tr>
+<tr>
+    <td><code>index</code></td>
+    <td><code>::=</code></td>
+    <td><code>[ {decimal digit}+ ]</code></td>
+</tr>
+<tr>
+    <td><code>segment</code></td>
+    <td><code>::=</code></td>
+    <td><code>. {symbol} | {singleq} | {doubleq} | {index}</code></td>
+</tr>
+<tr>
+    <td><code>parameter reference</code></td>
+    <td><code>::=</code></td>
+    <td><code>( {symbol} {segment}*)</code></td>
+</tr>
 </table>
-</p>
+</div>
 
 Use the following algorithm to resolve a parameter reference:
 


### PR DESCRIPTION
Fixes https://github.com/common-workflow-language/cwl-v1.2/issues/206

Instead of the plain strings used here: https://www.commonwl.org/v1.2/CommandLineTool.html#Parameter_references

Changes render as follows: 

![image](https://user-images.githubusercontent.com/19194484/200101356-05bb12d0-666b-4913-8055-a5035f8709b5.png)

Regarding the mention https://github.com/common-workflow-language/cwl-v1.2/issues/206#issuecomment-1302255446, I could find any other reference to `::` to adjust for `::=` other than in the table itself. 
Let me know (point me toward where) if the is somewhere specific to update. 
