### PR TITLE
Added conformance tests for File and Directory glob

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3392,3 +3392,51 @@
     }
   }
   tags: [ required, command_line_tool ]
+
+- id: capture_files
+  tool: tests/capture-files.cwl
+  job: tests/dir-job.yml
+  doc: Test that a type error is raised if directories are returned by glob evaluation when type is File
+  should_fail: true
+  tags: [ required, command_line_tool ]
+
+- id: capture_dirs
+  tool: tests/capture-dirs.cwl
+  job: tests/dir-job.yml
+  doc: Test that a type error is raised if files are returned by glob evaluation when type is Directory
+  should_fail: true
+  tags: [ required, command_line_tool ]
+
+- id: capture_files_and_dirs
+  tool: tests/capture-files-and-dirs.cwl
+  job: tests/dir-job.yml
+  doc: Test that both files and directories are captured by glob evaluation when type is [Directory, File]
+  output: {
+    "result": [
+      {
+        "basename": "a",
+        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "class": "File",
+        "size": 0
+      },
+      {
+        "basename": "b",
+        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "class": "File",
+        "size": 0
+      },
+      {
+        "basename": "c",
+        "class": "Directory",
+        "listing": [
+          {
+            "basename": "d",
+            "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+            "class": "File",
+            "size": 0
+          }
+        ]
+      }
+    ]
+  }
+  tags: [ required, command_line_tool ]

--- a/tests/capture-dirs.cwl
+++ b/tests/capture-dirs.cwl
@@ -1,0 +1,16 @@
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: [cp, -r]
+arguments:
+  - position: 2
+    valueFrom: $(runtime.outdir)
+inputs:
+  indir:
+    type: Directory
+    inputBinding:
+      position: 1
+outputs:
+  result:
+    type: Directory[]
+    outputBinding:
+      glob: $(inputs.indir.basename)/*

--- a/tests/capture-files-and-dirs.cwl
+++ b/tests/capture-files-and-dirs.cwl
@@ -1,0 +1,18 @@
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: [cp, -r]
+arguments:
+  - position: 2
+    valueFrom: $(runtime.outdir)
+inputs:
+  indir:
+    type: Directory
+    inputBinding:
+      position: 1
+outputs:
+  result:
+    type:
+      type: array
+      items: [File, Directory]
+    outputBinding:
+      glob: $(inputs.indir.basename)/*

--- a/tests/capture-files.cwl
+++ b/tests/capture-files.cwl
@@ -1,0 +1,16 @@
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: [cp, -r]
+arguments:
+  - position: 2
+    valueFrom: $(runtime.outdir)
+inputs:
+  indir:
+    type: Directory
+    inputBinding:
+      position: 1
+outputs:
+  result:
+    type: File[]
+    outputBinding:
+      glob: $(inputs.indir.basename)/*


### PR DESCRIPTION
Check that an error is thrown if `File` and `Directory` types are not correctly specified.