### PR TITLE
Document that ExpressionTool outputs are always valid

### DIFF
--- a/Workflow.yml
+++ b/Workflow.yml
@@ -120,6 +120,8 @@ $graph:
         typeDSL: True
       doc: |
         Specify valid types of data that may be assigned to this parameter.
+        Note that this field just acts as a hint, as the outputs of an
+        ExpressionTool process are always considered valid.
 
 
 - name: WorkflowInputParameter

--- a/concepts.md
+++ b/concepts.md
@@ -445,7 +445,7 @@ a [`cwl:tool`](#Executing_CWL_documents_as_scripts) entry) or by any other means
 1. Perform any further setup required by the specific process type.
 1. Execute the process.
 1. Capture results of process execution into the output object.
-1. Validate the output object against the `outputs` schema for the process.
+1. Validate the output object against the `outputs` schema for the process (with the exception of ExpressionTool outputs, which are always considered valid).
 1. Report the output object to the process caller.
 
 ## Requirements and hints


### PR DESCRIPTION
Up to CWL v1.2, type-checking never occurs for ExpressionTool output objects in the reference implementation. Therefore, it must be explicitly stated in the specification. The goal is then to fix this behaviour in CWL >= v1.3.