### PR TITLE
Fix typo {} vs ()

### DIFF
--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -517,7 +517,7 @@ $graph:
         type: File
         streamable: true
 
-    stdin: ${inputs.an_input_name.path}
+    stdin: $(inputs.an_input_name.path)
     ```
 
 - name: stdout


### PR DESCRIPTION
As reported at https://cwl.discourse.group/t/a-typo-on-commandlinetool-specification-stdin-example/797