### PR TITLE
Add JSON schema for CWL and conformance tests validating it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,8 @@ jobs:
       
       - name: Validate CWL documents
         run: ./run_test.sh --self
+
+      - name: Validate JSON schema document
+        run: |
+          pip install -r ./requirements-jsonschema-test.txt
+          pytest tests/json_schema

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+## IDE
+.idea/
+.vscode/
+
+## Python
+*.py[cod]
+*.egg[s]
+*.egg-info
+*egg[s]
+__pycache__
+.python_history

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -2633,7 +2633,7 @@
   tool: tests/timelimit2.cwl
   id: timelimit_invalid
   doc: Test invalid time limit value
-  tags: [ command_line_tool, timelimit ]
+  tags: [ command_line_tool, timelimit, json_schema_invalid ]
 
 - job: tests/empty.json
   output: {}

--- a/json-schema/cwl.yaml
+++ b/json-schema/cwl.yaml
@@ -1,0 +1,2236 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+$author: "Francis Charette-Migneault <francis.charette.migneault@gmail.com>"
+$id: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/1.2.1_proposed/json-schema/cwl.yaml"
+
+$defs:
+  CWL:
+    oneOf:
+      - $ref: '#/$defs/CWLAtomic'
+      - $ref: '#/$defs/CWLGraph'
+      - $ref: '#/$defs/CWLWorkflow'
+  CWLKeywordList:
+    type: array
+    title: KeywordList
+    description: Keywords applied to the process for search and categorization purposes.
+    items:
+      type: string
+      title: keyword
+      minLength: 1
+  CWLTextPatternID:
+    $comment: |
+      Identifier with text pattern that can allow additional non-ASCII characters depending on regex implementation.
+      The identifier allows a '#' or a relative 'sub/part#ref' prefix, to support references to other definitions
+      in the CWL document, such as when using 'SchemaDefRequirement'.
+
+      JSON spec regex does not include '\w' in its default subset to allow all word-like unicode characters
+      (see reference: https://json-schema.org/understanding-json-schema/reference/regular_expressions.html).
+
+      Since support is implementation specific, add both the ASCII-only and '\w' representation simultaneously
+      and let the parser reading this document apply whichever is more relevant or supported
+      (see discussion: https://github.com/common-workflow-language/cwl-v1.2/pull/256#discussion_r1234037814).
+    # TODO: implement specific characters supported by CWL
+    # (https://github.com/common-workflow-language/common-workflow-language/issues/429)
+    pattern: '^([A-Za-z0-9\w]+(/[A-Za-z0-9\w]+)*)?[#.]?[A-Za-z0-9\w]+(?:[-_.][A-Za-z0-9\w]+)*$'
+    type: string
+    description: Generic identifier name pattern.
+  CWLIdentifier:
+    anyOf:
+    - type: string
+      title: UUID
+      description: Unique identifier.
+      format: uuid
+      pattern: '^[a-f0-9]{8}(?:-?[a-f0-9]{4}){3}-?[a-f0-9]{12}$'
+    - $ref: '#/$defs/CWLTextPatternID'
+    title: CWLIdentifier
+    description: Reference to the process identifier.
+  CWLIntent:
+    type: array
+    title: CWLIntent
+    items:
+      type: string
+      title: item
+      description: |
+        Identifier URL to a concept for the type of computational operation accomplished by this process
+        (see example operations: http://edamontology.org/operation_0004).
+      format: url
+      pattern: '^((?:http|ftp)s?://)?(?!.*//.*$)(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+(?:[A-Za-z]{2,6}\.?|[A-Za-z0-9-]{2,}\.?)|localhost|\[[a-f0-9:]+\]|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::\d+)?(?:/?|[/?]\S+)$'
+  CWLImport:
+    description: |
+      Represents an '$import' directive that should point toward another compatible CWL file to import where specified.
+      The contents of the imported file should be relevant contextually where it is being imported.
+    $comment: |
+      The schema validation of the CWL will not itself perform the '$import' to resolve and validate its contents.
+      Therefore, the complete schema will not be validated entirely, and could still be partially malformed.
+      To ensure proper and exhaustive validation of a CWL definition with this schema, all '$import' directives
+      should be resolved and extended beforehand.
+    type: object
+    properties:
+      '$import':
+        type: string
+    required:
+      - '$import'
+    additionalProperties: false
+  CWLRequirements:
+    title: CWLRequirements
+    description: Explicit requirement to execute the application package.
+    oneOf:
+    - $ref: '#/$defs/CWLRequirementsMap'
+    - $ref: '#/$defs/CWLRequirementsList'
+  CWLRequirementsMap:
+    title: CWLRequirementsMap
+    type: object
+    properties:
+      cwltool:CUDARequirement:
+        $ref: '#/$defs/cwltool:CUDARequirement'
+      DockerRequirement:
+        $ref: '#/$defs/DockerRequirement'
+      SoftwareRequirement:
+        $ref: '#/$defs/SoftwareRequirement'
+      ShellCommandRequirement:
+        $ref: '#/$defs/ShellCommandRequirement'
+      EnvVarRequirement:
+        $ref: '#/$defs/EnvVarRequirement'
+      SchemaDefRequirement:
+        $ref: '#/$defs/SchemaDefRequirement'
+      InitialWorkDirRequirement:
+        $ref: '#/$defs/InitialWorkDirRequirement'
+      InlineJavascriptRequirement:
+        $ref: '#/$defs/InlineJavascriptRequirement'
+      InplaceUpdateRequirement:
+        $ref: '#/$defs/InplaceUpdateRequirement'
+      LoadListingRequirement:
+        $ref: '#/$defs/LoadListingRequirement'
+      NetworkAccess:
+        $comment: Not 'NetworkAccessRequirement'
+        $ref: '#/$defs/NetworkAccessRequirement'
+      ResourceRequirement:
+        $ref: '#/$defs/ResourceRequirement'
+      ScatterFeatureRequirement:
+        $ref: '#/$defs/ScatterFeatureRequirement'
+      ToolTimeLimit:
+        $comment: Not 'ToolTimeLimitRequirement'.
+        $ref: '#/$defs/ToolTimeLimitRequirement'
+      WorkReuse:
+        $comment: Not 'WorkReuseRequirement'.
+        $ref: '#/$defs/WorkReuseRequirement'
+      MultipleInputFeatureRequirement:
+        $ref: '#/$defs/MultipleInputFeatureRequirement'
+      StepInputExpressionRequirement:
+        $ref: '#/$defs/StepInputExpressionRequirement'
+      SubworkflowFeatureRequirement:
+        $ref: '#/$defs/SubworkflowFeatureRequirement'
+    additionalProperties: false
+  DockerRequirement:
+    type: object
+    title: DockerRequirement
+    properties:
+      class:
+        type: string
+        enum:
+          - DockerRequirement
+      dockerPull:
+        type: string
+        title: Docker pull reference
+        description: Reference package that will be retrieved and executed by CWL.
+        example: docker-registry.host.com/namespace/image:1.2.3
+      dockerImport:
+        type: string
+      dockerLoad:
+        type: string
+      dockerFile:
+        type: string
+      dockerImageId:
+        type: string
+      dockerOutputDirectory:
+        type: string
+    oneOf:
+      - required: [dockerPull]
+      - required: [dockerImport]
+      - required: [dockerLoad]
+      - required: [dockerFile]
+    additionalProperties: false
+  InitialWorkDirListing:
+    title: InitialWorkDirListing
+    oneOf:
+      - $ref: '#/$defs/CWLExpression'
+      - type: array
+        title: InitialWorkDirListingItems
+        items:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/$defs/CWLExpression'
+            - $ref: '#/$defs/DirectoryListingDirent'
+            - $ref: '#/$defs/DirectoryListingFileOrDirectory'
+            - type: array
+              items:
+                $ref: '#/$defs/DirectoryListingFileOrDirectory'
+  DirectoryListingFileOrDirectory:
+    type: object
+    properties:
+      class:
+        type: string
+        enum:
+          - File
+          - Directory
+      location:
+        type: string
+      checksum:
+        $ref: '#/$defs/Checksum'
+      size:
+        type: integer
+        minimum: 0
+    required:
+      - class
+      - location
+    additionalProperties: false
+  DirectoryListingDirent:
+    $comment: Called 'Dirent' in documentation.
+    type: object
+    title: DirectoryListingDirent
+    properties:
+      entry:
+        $ref: '#/$defs/CWLExpression'
+      entryname:
+        $ref: '#/$defs/CWLExpression'
+      writable:
+        type: boolean
+    required:
+      - entry
+    additionalProperties: false
+  InitialWorkDirRequirement:
+    type: object
+    title: InitialWorkDirRequirement
+    properties:
+      class:
+        type: string
+        enum:
+          - InitialWorkDirRequirement
+      listing:
+        $ref: '#/$defs/InitialWorkDirListing'
+    required:
+    - listing
+    additionalProperties: false
+  InlineJavascriptLibObject:
+    type: object
+    properties:
+      '$include':
+        type: string
+    required:
+      - '$include'
+    additionalProperties: false
+  InlineJavascriptLibItem:
+    oneOf:
+      - type: string
+      - $ref: '#/$defs/InlineJavascriptLibObject'
+  InlineJavascriptLibraries:
+    type: array
+    title: InlineJavascriptLibraries
+    description: |
+      Additional code fragments that will also be inserted before executing the expression code.
+      Allows for function definitions that may be called from CWL expressions.
+    items:
+      title: exp_lib
+      $ref: '#/$defs/InlineJavascriptLibItem'
+  InlineJavascriptRequirement:
+    type: object
+    title: InlineJavascriptRequirement
+    description: |
+      Indicates that the workflow platform must support inline Javascript expressions.
+
+      If this requirement is not present, the workflow platform must not perform expression interpolation
+      (see also: https://www.commonwl.org/v1.2/CommandLineTool.html#InlineJavascriptRequirement).
+    properties:
+      class:
+        type: string
+        enum:
+          - InlineJavascriptRequirement
+      expressionLib:
+        $ref: '#/$defs/InlineJavascriptLibraries'
+      required:
+        - expressionLib
+    additionalProperties: false
+  InplaceUpdateRequirement:
+    type: object
+    title: InplaceUpdateRequirement
+    description: |
+      If 'inplaceUpdate' is true, then an implementation supporting this feature may permit tools to directly
+      update files with 'writable: true' in 'InitialWorkDirRequirement'. That is, as an optimization,
+      files may be destructively modified in place as opposed to copied and updated
+      (see also: https://www.commonwl.org/v1.2/CommandLineTool.html#InplaceUpdateRequirement).
+    properties:
+      class:
+        type: string
+        enum:
+          - InplaceUpdateRequirement
+      inplaceUpdate:
+        type: boolean
+        title: inplaceUpdate
+    required:
+    - inplaceUpdate
+    additionalProperties: false
+  LoadListingEnum:
+    type: string
+    title: LoadListingEnum
+    enum:
+    - no_listing
+    - shallow_listing
+    - deep_listing
+  LoadListingRequirement:
+    type: object
+    title: LoadListingRequirement
+    description: |
+      Specify the desired behavior for loading the listing field of a 'Directory' object for use by expressions
+      (see also: https://www.commonwl.org/v1.2/CommandLineTool.html#LoadListingRequirement).
+    properties:
+      class:
+        type: string
+        enum:
+        - LoadListingRequirement
+      loadListing:
+        $ref: '#/$defs/LoadListingEnum'
+    required:
+    - loadListing
+    additionalProperties: false
+  NetworkAccess:
+    title: NetworkAccess
+    description: Indicate whether a process requires outgoing IPv4/IPv6 network access.
+    example: true
+    oneOf:
+    - type: boolean
+    - $ref: '#/$defs/CWLExpression'
+  NetworkAccessRequirement:
+    type: object
+    title: NetworkAccessRequirement
+    properties:
+      class:
+        type: string
+        $comment: Not 'NetworkAccessRequirement'
+        enum:
+          - NetworkAccess
+      networkAccess:
+        $ref: '#/$defs/NetworkAccess'
+    required:
+    - networkAccess
+    additionalProperties: false
+  CWLExpression:
+    $comment: |
+      Whenever this option is applicable for a parameter, any other 'normal' string should not be specified.
+      For JSON schema validation, there is no easy way to distinguish them unless using complicated string patterns.
+    type: string
+    title: CWLExpression
+    description: |
+      When combined with 'InlineJavascriptRequirement', this field allows runtime parameter references
+      (see also: https://www.commonwl.org/v1.2/CommandLineTool.html#Expression).
+  ResourceQuantityOrFractional:
+    description: An item quantity that can also represent a proportion of use by resources.
+    $comment: |
+      Technically should be minimum=1, but fractional for scheduling algorithms are allowed.
+      There is no way to distinguish between float/long simultaneously in JSON schema (multi-match oneOf).
+      Therefore, only validate that it is greater than zero.
+    type: number
+    exclusiveMinimum: 0
+    default: 1
+  ResourceCoresMinimum:
+    oneOf:
+    - $ref: '#/$defs/ResourceQuantityOrFractional'
+    - $ref: '#/$defs/CWLExpression'
+    title: ResourceCoresMinimum
+    summary: Minimum reserved number of CPU cores.
+    description: |
+      Minimum reserved number of CPU cores.
+      
+      May be a fractional value to indicate to a scheduling algorithm that one core can be allocated to
+      multiple jobs. For example, a value of 0.25 indicates that up to 4 jobs
+      may run in parallel on 1 core. A value of 1.25 means that up to 3 jobs
+      can run on a 4 core system (4/1.25 ~ 3).
+      
+      Processes can only share a core allocation if the sum of each of their 'ramMax', 'tmpdirMax', and
+      'outdirMax' requests also do not exceed the capacity of the node.
+      
+      Processes sharing a core must have the same level of isolation (typically a container
+      or VM) that they would normally have.
+      
+      The reported number of CPU cores reserved for the process, which is available to expressions 
+      on the 'CommandLineTool' as 'runtime.cores', must be a non-zero integer, and may be calculated by
+      rounding up the cores request to the next whole number.
+      
+      Scheduling systems may allocate fractional CPU resources by setting quotas or scheduling weights.
+      Scheduling systems that do not support fractional CPUs may round up the request to the next whole number.
+    default: 1
+  ResourceCoresMaximum:
+    oneOf:
+    - $ref: '#/$defs/ResourceQuantityOrFractional'
+    - $ref: '#/$defs/CWLExpression'
+    title: ResourceCoresMaximum
+    summary: Maximum reserved number of CPU cores.
+    description: |
+      Maximum reserved number of CPU cores.
+      See 'coresMin' for discussion about fractional CPU requests.
+  ResourceRAMMinimum:
+    oneOf:
+    - $ref: '#/$defs/ResourceQuantityOrFractional'
+    - $ref: '#/$defs/CWLExpression'
+    title: ResourceRAMMinimum
+    summary: Minimum reserved RAM in mebibytes.
+    description: |
+      Minimum reserved RAM in mebibytes (2**20).
+
+      May be a fractional value. If so, the actual RAM request must be rounded up
+      to the next whole number.
+
+      The reported amount of RAM reserved for the process, which is available to
+      expressions on the 'CommandLineTool' as 'runtime.ram', must be a non-zero integer.
+    default: 256
+  ResourceRAMMaximum:
+    oneOf:
+    - $ref: '#/$defs/ResourceQuantityOrFractional'
+    - $ref: '#/$defs/CWLExpression'
+    title: ResourceRAMMaximum
+    summary: Maximum reserved RAM in mebibytes.
+    description: |
+      Maximum reserved RAM in mebibytes (2**20).
+      See 'ramMin' for discussion about fractional RAM requests.
+  ResourceTmpDirMinimum:
+    oneOf:
+    - $ref: '#/$defs/ResourceQuantityOrFractional'
+    - $ref: '#/$defs/CWLExpression'
+    title: ResourceTmpDirMinimum
+    summary: Minimum reserved filesystem based storage for the designated temporary
+      directory in mebibytes.
+    description: | 
+      Minimum reserved filesystem based storage for the designated temporary
+      directory in mebibytes (2**20).
+
+      May be a fractional value. If so, the actual storage request must be rounded
+      up to the next whole number.
+
+      The reported amount of storage reserved for the process, which is available
+      to expressions on the 'CommandLineTool' as 'runtime.tmpdirSize', must be a non-zero integer.
+    default: 1024
+  ResourceTmpDirMaximum:
+    oneOf:
+    - $ref: '#/$defs/ResourceQuantityOrFractional'
+    - $ref: '#/$defs/CWLExpression'
+    title: ResourceTmpDirMaximum
+    summary: Maximum reserved filesystem based storage for the designated temporary directory in mebibytes.
+    description: |
+      Maximum reserved filesystem based storage for the designated temporary directory in mebibytes (2**20).
+      See 'tmpdirMin' for discussion about fractional storage requests.
+  ResourceOutDirMinimum:
+    oneOf:
+    - $ref: '#/$defs/ResourceQuantityOrFractional'
+    - $ref: '#/$defs/CWLExpression'
+    title: ResourceOutDirMinimum
+    summary: Minimum reserved filesystem based storage for the designated output
+      directory in mebibytes.
+    description: |
+      Minimum reserved filesystem based storage for the designated output
+      directory in mebibytes (2**20).
+
+      May be a fractional value. If so, the actual storage request must be rounded
+      up to the next whole number.
+
+      The reported amount of storage reserved for the process, which is available
+      to expressions on the 'CommandLineTool' as 'runtime.outdirSize', must be a non-zero integer.
+    default: 1024
+  ResourceOutDirMaximum:
+    oneOf:
+    - $ref: '#/$defs/ResourceQuantityOrFractional'
+    - $ref: '#/$defs/CWLExpression'
+    title: ResourceOutDirMaximum
+    summary: Maximum reserved filesystem based storage for the designated output
+      directory in mebibytes.
+    description: |
+      Maximum reserved filesystem based storage for the designated output
+      directory in mebibytes (2**20).
+      See 'outdirMin' for discussion about fractional storage requests.
+    default: 1
+  ResourceRequirement:
+    type: object
+    title: ResourceRequirement
+    description: |
+      Specify basic hardware resource requirements
+      (see also: https://www.commonwl.org/v1.2/CommandLineTool.html#ResourceRequirement).
+    properties:
+      class:
+        type: string
+        enum:
+          - ResourceRequirement
+      coresMin:
+        $ref: '#/$defs/ResourceCoresMinimum'
+      coresMax:
+        $ref: '#/$defs/ResourceCoresMaximum'
+      ramMin:
+        $ref: '#/$defs/ResourceRAMMinimum'
+      ramMax:
+        $ref: '#/$defs/ResourceRAMMaximum'
+      tmpdirMin:
+        $ref: '#/$defs/ResourceTmpDirMinimum'
+      tmpdirMax:
+        $ref: '#/$defs/ResourceTmpDirMaximum'
+      outdirMin:
+        $ref: '#/$defs/ResourceOutDirMinimum'
+      outdirMax:
+        $ref: '#/$defs/ResourceOutDirMaximum'
+    additionalProperties: false
+  Scatter:
+    oneOf:
+    - $ref: '#/$defs/CWLTextPatternID'
+    - $ref: '#/$defs/IdentifierArray'
+    title: Scatter
+    description: |
+      The scatter field specifies one or more input parameters which will be scattered.
+
+      An input parameter may be listed more than once. The declared type of each
+      input parameter implicitly becomes an array of items of the input parameter type.
+      If a parameter is listed more than once, it becomes a nested array. As a result,
+      upstream parameters which are connected to scattered parameters must be arrays.
+
+      All output parameter types are also implicitly wrapped in arrays. Each job
+      in the scatter results in an entry in the output array.
+
+      If any scattered parameter runtime value is an empty array, all outputs are
+      set to empty arrays and no work is done for the step, according to applicable scattering rules.
+  IdentifierArray:
+    type: array
+    title: IdentifierArray
+    items:
+      $ref: '#/$defs/CWLTextPatternID'
+    minItems: 1
+  ScatterFeatureRequirement:
+    type: object
+    title: ScatterFeatureRequirement
+    description: |
+      A 'scatter' operation specifies that the associated Workflow step should execute separately over a list of
+      input elements. Each job making up a scatter operation is independent and may be executed concurrently
+      (see also: https://www.commonwl.org/v1.2/Workflow.html#WorkflowStep).
+    $comment: Fields 'scatter' and 'scatterMethod' at the root of a 'WorkflowStep', not within the requirement.
+    properties:
+      class:
+        type: string
+        description: CWL requirement class specification.
+        enum:
+          - ScatterFeatureRequirement
+    additionalProperties: false
+  MultipleInputFeatureRequirement:
+    type: object
+    title: MultipleInputFeatureRequirement
+    description: |
+      Indicates that the 'Workflow' must support multiple inbound data links listed in the 'source'
+      field of 'WorkflowStepInput'.
+    properties:
+      class:
+        type: string
+        description: CWL requirement class specification.
+        enum:
+          - MultipleInputFeatureRequirement
+    additionalProperties: false
+  StepInputExpressionRequirement:
+    type: object
+    title: StepInputExpressionRequirement
+    description: Indicates that the 'Workflow' must support the 'valueFrom' field of 'WorkflowStepInput'.
+    properties:
+      class:
+        type: string
+        description: CWL requirement class specification.
+        enum:
+          - StepInputExpressionRequirement
+    additionalProperties: false
+  SubworkflowFeatureRequirement:
+    type: object
+    title: SubworkflowFeatureRequirement
+    description: Indicates that the 'Workflow' must support nested workflows in the 'run' field of 'WorkflowStep'.
+    properties:
+      class:
+        type: string
+        description: CWL requirement class specification.
+        enum:
+          - SubworkflowFeatureRequirement
+    additionalProperties: false
+  CWLFileOnlyParameters:
+    type: object
+    properties:
+      secondaryFiles:
+        $ref: '#/$defs/CWLTypeRecordSecondaryFiles'
+      streamable:
+        type: boolean
+      format:
+        $ref: '#/$defs/CWLFormat'
+      loadContents:
+        type: boolean
+  CWLFileOnlyParametersConditional:
+    description: Parameters that are only valid when 'type' or 'items' evaluates to 'File'.
+    $comment: |
+      Explicitly disallow these parameters when non-File type is detected.
+      Otherwise, validate their schema definitions according to what is permitted.
+    type: object
+    if:
+      properties:
+        oneOf:
+        - $comment: Single required or optional 'File'.
+          type:
+            enum:
+            - File
+            - File?
+            - File[]
+            - File[]?
+        - $comment: Array of required or optional 'File'.
+          type:
+            const: array
+          items:
+            oneOf:
+              - type:
+                - const: File
+                - const: File?
+              - type: array
+                contains:
+                  type:
+                    - const: File
+                    - const: File?
+    then:
+      $ref: '#/$defs/CWLFileOnlyParameters'
+    else:
+      not:
+        properties:
+          secondaryFiles: {}
+          streamable: {}
+          format: {}
+          loadContents: {}
+  CWLDirectoryOnlyParameters:
+    type: object
+    properties:
+      loadListing:
+        $ref: '#/$defs/LoadListingEnum'
+  CWLDirectoryOnlyParametersConditional:
+    description: Parameters that are only valid when 'type' or 'items' evaluates to 'Directory'.
+    $comment: |
+      Explicitly disallow these parameters when non-Directory type is detected.
+      Otherwise, validate their schema definitions according to what is permitted.
+    type: object
+    if:
+      properties:
+        oneOf:
+        - $comment: Single required or optional 'Directory'.
+          type:
+            enum:
+            - Directory
+            - Directory?
+            - Directory[]
+            - Directory[]?
+        - $comment: Array of required or optional 'Directory'.
+          type:
+            const: array
+          items:
+            oneOf:
+              - type:
+                - const: Directory
+                - const: Directory?
+              - type: array
+                contains:
+                  type:
+                    - const: Directory
+                    - const: Directory?
+    then:
+      $ref: '#/$defs/CWLDirectoryOnlyParameters'
+    else:
+      not:
+        properties:
+          loadListing: {}
+  CWLTypeRecordSecondaryFileSchema:
+    type: object
+    properties:
+      pattern:
+        $comment: Either an expression or the regex pattern directly.
+        $ref: '#/$defs/CWLExpression'
+      required:
+        oneOf:
+          - type: boolean
+          - $ref: '#/$defs/CWLExpression'
+    required:
+      - pattern
+    additionalProperties: false
+  CWLTypeRecordSecondaryFiles:
+    oneOf:
+      - $comment: Either an expression or the regex pattern directly.
+        $ref: '#/$defs/CWLExpression'
+      - $ref: '#/$defs/CWLTypeRecordSecondaryFileSchema'
+      - type: array
+        items:
+          $comment: Either an expression or the regex pattern directly.
+          $ref: '#/$defs/CWLExpression'
+      - type: array
+        items:
+          $ref: '#/$defs/CWLTypeRecordSecondaryFileSchema'
+  CWLTypeRecordFieldDefBase:
+    type: object
+    properties:
+      name:
+        $comment: |
+          Required if list item. Otherwise, optional since it is the mapping key.
+          This requirement is defined in 'CWLTypeRecordFieldsItem' to allow reuse of this schema.
+        type: string
+      type:
+        $ref: '#/$defs/CWLType'
+    required:
+      - type
+  CWLTypeRecordFieldDef:
+    allOf:
+      - $ref: '#/$defs/CWLTypeRecordFieldDefBase'
+      - $ref: '#/$defs/CWLFileOnlyParametersConditional'
+      - $ref: '#/$defs/CWLDirectoryOnlyParametersConditional'
+  CWLTypeRecordFieldsMap:
+    type: object
+    additionalProperties:
+      oneOf:
+        - $ref: '#/$defs/CWLType'
+        - $ref: '#/$defs/CWLTypeRecordFieldDef'
+  CWLTypeRecordFieldsItem:
+    allOf:
+      - $ref: '#/$defs/CWLTypeRecordFieldDef'
+      - required:
+        - name
+  CWLTypeRecordFieldsList:
+    type: array
+    items:
+      $ref: '#/$defs/CWLTypeRecordFieldsItem'
+  CWLTypeRecordFields:
+    oneOf:
+      - $ref: '#/$defs/CWLTypeRecordFieldsMap'
+      - $ref: '#/$defs/CWLTypeRecordFieldsList'
+  CWLTypeRecordSchema:
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - record
+      fields:
+        $ref: '#/$defs/CWLTypeRecordFields'
+      name:
+        type: string
+    required:
+      - type
+  CWLTypeRecordArray:
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - array
+      items:
+        $ref: '#/$defs/CWLType'
+    required:
+      - type
+      - items
+  SchemaDefRequirement:
+    type: object
+    properties:
+      class:
+        type: string
+        enum:
+          - SchemaDefRequirement
+      types:
+        type: array
+        items:
+          oneOf:
+            - $ref: '#/$defs/CWLTypeEnum'
+            - $ref: '#/$defs/CWLTypeRecordSchema'
+            - $ref: '#/$defs/CWLTypeRecordArray'
+            - $ref: '#/$defs/CWLImport'
+    required:
+      - types
+    additionalProperties: false
+  SoftwarePackageSpecs:
+    type: array
+    items:
+      type: string
+  SoftwarePackage:
+    type: object
+    properties:
+      package:
+        type: string
+      version:
+        type: array
+        items:
+          type: string
+      specs:
+        type: array
+        items:
+          $ref: '#/$defs/ReferenceURL'
+    required:
+      - package
+    additionalProperties: false
+  SoftwareRequirement:
+    type: object
+    properties:
+      class:
+        type: string
+        enum:
+          - SoftwareRequirement
+      packages:
+        oneOf:
+          - type: array
+            items:
+              $ref: '#/$defs/SoftwarePackage'
+          - type: object
+            description: Mapping of 'package' name to its specifications.
+            additionalProperties:
+              oneOf:
+                - $ref: '#/$defs/SoftwarePackageSpecs'
+                - $ref: '#/$defs/SoftwarePackage'
+    required:
+      - packages
+    additionalProperties: false
+  ShellCommandRequirement:
+    type: object
+    properties:
+      class:
+        type: string
+        enum:
+          - ShellCommandRequirement
+    additionalProperties: false
+  EnvironmentDef:
+    type: object
+    properties:
+      envName:
+        type: string
+        minLength: 1
+      envValue:
+        type:
+          $ref: '#/$defs/CWLExpression'
+    required:
+      - envName
+      - envValue
+    additionalProperties: false
+  EnvVarRequirement:
+    type: object
+    properties:
+      class:
+        type: string
+        enum:
+          - EnvVarRequirement
+      envDef:
+        oneOf:
+          - type: array
+            items:
+              $ref: '#/$defs/EnvironmentDef'
+          - type: object
+            description: Mapping of 'envName' to environment value or definition.
+            additionalProperties:
+              oneOf:
+                - description: The 'envValue' specified directly
+                  $ref: '#/$defs/CWLExpression'
+                - $ref: '#/$defs/EnvironmentDef'
+    required:
+      - envDef
+    additionalProperties: false
+  TimeLimitValue:
+    oneOf:
+    - type: number
+      minimum: 0.0
+    - $ref: '#/$defs/CWLExpression'
+    title: TimeLimitValue
+    description: |
+      The time limit, in seconds.
+
+      A time limit of zero means no time limit.
+      Negative time limits are an error.
+  ToolTimeLimitRequirement:
+    type: object
+    title: ToolTimeLimitRequirement
+    description: |
+      Set an upper limit on the execution time of a CommandLineTool.
+
+      A CommandLineTool whose execution duration exceeds the time limit may be preemptively
+      terminated and considered failed. May also be used by batch systems to make scheduling decisions.
+
+      The execution duration excludes external operations, such as staging of files,
+      pulling a docker image etc., and only counts wall-time for the execution of the command line itself.
+    properties:
+      class:
+        type: string
+        $comment: not 'ToolTimeLimitRequirement'
+        enum:
+          - ToolTimeLimit
+      timelimit:
+        $ref: '#/$defs/TimeLimitValue'
+    required:
+    - timelimit
+    additionalProperties: false
+  EnableReuseValue:
+    oneOf:
+    - type: boolean
+    - $ref: '#/$defs/CWLExpression'
+    title: EnableReuseValue
+    description: |
+      Indicates if reuse is enabled for this tool.
+
+      Can be an expression when combined with 'InlineJavascriptRequirement'
+      (see also: https://www.commonwl.org/v1.2/CommandLineTool.html#Expression).
+  WorkReuseRequirement:
+    type: object
+    title: WorkReuseRequirement
+    description: |
+      For implementations that support reusing output from past work
+      (on the assumption that same code and same input produce same results),
+      control whether to enable or disable the reuse behavior for a particular tool
+      or step (to accommodate situations where that assumption is incorrect).
+
+      A reused step is not executed but instead returns the same output as the original execution.
+
+      If 'WorkReuse' is not specified, correct tools should assume it is enabled by default.
+    properties:
+      class:
+        type: string
+        $comment: Not 'WorkReuseRequirement'.
+        enum:
+          - WorkReuse
+      enableReuse:
+        $ref: '#/$defs/EnableReuseValue'
+    required:
+    - enableReuse
+    additionalProperties: false
+  UnknownRequirement:
+    type: object
+    description: Generic schema to allow alternative CWL requirements/hints not explicitly defined in schemas.
+    properties:
+      class:
+        type: string
+        title: Requirement Class Identifier
+        description: CWL requirement class specification.
+        example: UnknownRequirement
+        not:
+          enum:
+            - cwltool:CUDARequirement
+            - DockerRequirement
+            - SoftwareRequirement
+            - ShellCommandRequirement
+            - EnvVarRequirement
+            - SchemaDefRequirement
+            - InitialWorkDirRequirement
+            - InlineJavascriptRequirement
+            - InplaceUpdateRequirement
+            - LoadListingRequirement
+            - NetworkAccess
+            - ResourceRequirement
+            - ScatterFeatureRequirement
+            - ToolTimeLimit
+            - WorkReuse
+            - MultipleInputFeatureRequirement
+            - StepInputExpressionRequirement
+            - SubworkflowFeatureRequirement
+    additionalProperties: {}
+  CWLRequirementsList:
+    type: array
+    title: CWLRequirementsList
+    items:
+      oneOf:
+      - allOf:
+        - $comment: |
+            When using the list representation, 'class' is required to indicate which one is being represented.
+            When using the mapping representation, 'class' is optional since it's the key, but it must match by name.
+          required:
+          - class
+        - $ref: '#/$defs/CWLRequirementsItem'
+      - $ref: '#/$defs/CWLImport'
+  CWLRequirementsItem:
+    title: CWLRequirementsItem
+    $comment: |
+      For any new items added, ensure they are added under 'class' of 'UnknownRequirement' as well.
+      Otherwise, insufficiently restrictive classes could cause multiple matches, failing the 'oneOf' condition.
+    oneOf:
+      - $ref: '#/$defs/cwltool:CUDARequirement'
+      - $ref: '#/$defs/DockerRequirement'
+      - $ref: '#/$defs/SoftwareRequirement'
+      - $ref: '#/$defs/ShellCommandRequirement'
+      - $ref: '#/$defs/EnvVarRequirement'
+      - $ref: '#/$defs/SchemaDefRequirement'
+      - $ref: '#/$defs/InitialWorkDirRequirement'
+      - $ref: '#/$defs/InlineJavascriptRequirement'
+      - $ref: '#/$defs/InplaceUpdateRequirement'
+      - $ref: '#/$defs/LoadListingRequirement'
+      - $ref: '#/$defs/NetworkAccessRequirement'
+      - $ref: '#/$defs/ResourceRequirement'
+      - $ref: '#/$defs/ScatterFeatureRequirement'
+      - $ref: '#/$defs/ToolTimeLimitRequirement'
+      - $ref: '#/$defs/WorkReuseRequirement'
+      - $ref: '#/$defs/MultipleInputFeatureRequirement'
+      - $ref: '#/$defs/StepInputExpressionRequirement'
+      - $ref: '#/$defs/SubworkflowFeatureRequirement'
+  ScatterMethod:
+    type: string
+    title: scatterMethod
+    description: |
+      If 'scatter' declares more than one input parameter, 'scatterMethod'
+      describes how to decompose the input into a discrete set of jobs.
+      
+      - dotproduct: specifies that each of the input arrays are aligned and
+        one element taken from each array to construct each job. It is an
+        error if all input arrays are not the same length.
+      
+      - nested_crossproduct: specifies the Cartesian product of the inputs, producing 
+        a job for every combination of the scattered inputs. The output must be nested 
+        arrays for each level of scattering, in the order that the input arrays
+        are listed in the 'scatter' field.
+      
+      - flat_crossproduct: specifies the Cartesian product of the inputs, producing a 
+        job for every combination of the scattered inputs. The output arrays must be 
+        flattened to a single level, but otherwise listed in the order that the input 
+        arrays are listed in the 'scatter' field.
+    default: dotproduct
+    enum:
+    - dotproduct
+    - nested_crossproduct
+    - flat_crossproduct
+    required:
+    - timelimit
+    - class
+    additionalProperties: false
+  CWLHints:
+    oneOf:
+    - $ref: '#/$defs/CWLHintsMap'
+    - $ref: '#/$defs/CWLHintsList'
+    title: CWLHints
+    description: Non-failing additional hints that can help resolve extra requirements.
+  CWLHintsMapExtras:
+    type: object
+    properties:
+      BuiltinRequirement:
+        $ref: '#/$defs/BuiltinRequirement'
+      OGCAPIRequirement:
+        $ref: '#/$defs/OGCAPIRequirement'
+      WPS1Requirement:
+        $ref: '#/$defs/WPS1Requirement'
+    additionalProperties:
+      $ref: '#/$defs/UnknownRequirement'
+  CWLHintsMap:
+    title: CWLHintsMap
+    anyOf:
+      - $ref: '#/$defs/CWLRequirementsMap'
+      - $ref: '#/$defs/CWLHintsMapExtras'
+  BuiltinRequirement:
+    type: object
+    title: BuiltinRequirement
+    description: |
+      Hint indicating that the Application Package corresponds to a
+      builtin process of this instance. (note: can only be an 'hint'
+      as it is unofficial CWL specification).
+    properties:
+      class:
+        type: string
+        enum:
+        - BuiltinRequirement
+      process:
+        $comment: Builtin process identifier.
+        $ref: '#/$defs/CWLTextPatternID'
+    required:
+    - process
+    - class
+    additionalProperties: false
+  CUDAComputeCapability:
+    oneOf:
+    - type: string
+      title: CUDA compute capability
+      description: The compute capability supported by the GPU hardware.
+      pattern: '^\d+\.\d+$'
+    - $ref: '#/$defs/CUDAComputeCapabilityArray'
+    title: CUDA compute capability
+    description: |
+      The compute capability supported by the GPU hardware.
+      
+      * If this is a single value, it defines only the minimum compute capability.
+        GPUs with higher capability are also accepted.
+      * If it is an array value, then only select GPUs with compute capabilities that explicitly
+        appear in the array.
+        See https://docs.nvidia.com/deploy/cuda-compatibility/#faq and
+        https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#cuda-compute-capability
+        for details.
+  CUDAComputeCapabilityArray:
+    type: array
+    title: CUDAComputeCapabilityArray
+    items:
+      type: string
+      title: CUDA compute capability
+      description: The compute capability supported by the GPU hardware.
+      pattern: '^\d+\.\d+$'
+    minItems: 1
+  cwltool:CUDARequirement:
+    type: object
+    title: cwltool:CUDARequirement
+    properties:
+      class:
+        type: string
+        enum:
+          - cwltool:CUDARequirement
+      cudaVersionMin:
+        type: string
+        title: CUDA version minimum
+        description: | 
+          The minimum CUDA version required to run the software. This corresponds to a CUDA SDK release.
+
+          When run in a container, the container image should provide the CUDA runtime,
+          and the host driver is injected into the container.  In this case, because CUDA drivers
+          are backwards compatible, it is possible to use an older SDK with a newer driver across major versions.
+
+          See https://docs.nvidia.com/deploy/cuda-compatibility/ for details.
+        example: '11.4'
+        pattern: '^\d+\.\d+$'
+      cudaComputeCapability:
+        $ref: '#/$defs/CUDAComputeCapability'
+      cudaDeviceCountMin:
+        type: integer
+        title: CUDA device count minimum
+        description: The minimum amount of devices required.
+        default: 1
+        example: 1
+        minimum: 1
+      cudaDeviceCountMax:
+        type: integer
+        title: CUDA device count maximum
+        description: The maximum amount of devices required.
+        default: 1
+        example: 8
+        minimum: 1
+    required:
+    - cudaVersionMin
+    - cudaComputeCapability
+    additionalProperties: false
+  OGCAPIRequirement:
+    type: object
+    title: OGCAPIRequirement
+    description: | 
+      Hint indicating that the Application Package corresponds to an
+      OGC API - Processes provider that should be remotely executed and monitored
+      by this instance. (note: can only be an 'hint' as it is unofficial CWL specification).
+    properties:
+      class:
+        type: string
+        enum:
+        - OGCAPIRequirement
+      process:
+        description: Process location.
+        $ref: '#/$defs/ReferenceURL'
+    required:
+    - process
+    additionalProperties: false
+  WPS1Requirement:
+    type: object
+    title: WPS1Requirement
+    description: |
+      Hint indicating that the Application Package corresponds to a
+      WPS-1 provider process that should be remotely executed and monitored by this
+      instance. (note: can only be an ''hint'' as it is unofficial CWL specification).
+    properties:
+      class:
+        type: string
+        enum:
+          - WPS1Requirement
+      process:
+        $comment: Process identifier of the remote WPS provider.
+        $ref: '#/$defs/CWLTextPatternID'
+      provider:
+        description: WPS provider endpoint.
+        $ref: '#/$defs/ReferenceURL'
+    required:
+    - process
+    - provider
+    additionalProperties: false
+  CWLHintsList:
+    type: array
+    title: CWLHintsList
+    items:
+      oneOf:
+      - allOf:
+        - $comment: |
+            When using the list representation, 'class' is required to indicate which one is being represented.
+            When using the mapping representation, 'class' is optional since it's the key, but it must match by name.
+          required:
+          - class
+        - $ref: '#/$defs/CWLHintsItem'
+      - $ref: '#/$defs/CWLImport'
+  CWLHintsItemExtras:
+    oneOf:
+    - $ref: '#/$defs/BuiltinRequirement'
+    - $ref: '#/$defs/OGCAPIRequirement'
+    - $ref: '#/$defs/WPS1Requirement'
+    - $ref: '#/$defs/UnknownRequirement'
+  CWLHintsItem:
+    title: CWLHintsItem
+    $comment: |
+      For any new items added, ensure they are added under 'class' of 'UnknownRequirement' as well.
+      Otherwise, insufficiently restrictive classes could cause multiple matches, failing the 'oneOf' condition.
+    oneOf:
+    - $ref: '#/$defs/CWLRequirementsItem'
+    - $ref: '#/$defs/CWLHintsItemExtras'
+  CWLCommand:
+    oneOf:
+    - type: string
+      title: String command.
+    - $ref: '#/$defs/CommandParts'
+    title: CWLCommand
+    description: |
+      Command called in the docker image or on shell according to requirements
+      and hints specifications. Can be omitted if already defined in the docker
+      image.
+  CommandParts:
+    type: array
+    title: Command Parts
+    items:
+      type: string
+      title: cmd
+    additionalProperties: false
+  CWLArguments:
+    type: array
+    title: CWLArguments
+    description: Base arguments passed to the command.
+    items:
+      oneOf:
+      - type: string
+      - $ref: '#/$defs/InputBinding'
+  CWLInputStdInDefinition:
+    description: |
+      Indicates that the value passed to this CWL input will be redirected to the standard input stream of the command.
+      Can be defined for only one input and must not be combined with 'stdin' at the root of the CWL document.
+    type: string
+    enum:
+      - stdin
+  CWLInputStdInObjectType:
+    type: object
+    properties:
+      type:
+        $ref: '#/$defs/CWLInputStdInDefinition'
+    required:
+      - type
+  CWLInputStdIn:
+    oneOf:
+      - $ref: '#/$defs/CWLInputStdInDefinition'
+      - $ref: '#/$defs/CWLInputStdInObjectType'
+  CWLOutputStdOutDefinition:
+    description: |
+      Indicates that the data pushed to the standard output stream by the command will be redirected to this CWL output.
+      Can be defined for only one output. If combined with 'stdout' at the root of the CWL document, that definition
+      will indicate the desired name of the output file where the output stream will be written to. A random name will
+      be applied for the file of this output unless otherwise specified.
+    type: string
+    enum:
+      - stdout
+  CWLOutputStdOutObjectType:
+    type: object
+    properties:
+      type:
+        $ref: '#/$defs/CWLOutputStdOutDefinition'
+    required:
+      - type
+  CWLOutputStdOut:
+    oneOf:
+      - $ref: '#/$defs/CWLOutputStdOutDefinition'
+      - $ref: '#/$defs/CWLOutputStdOutObjectType'
+  CWLOutputStdErrDefinition:
+    description: |
+      Indicates that the data pushed to the standard error stream by the command will be redirected to this CWL output.
+      Can be defined for only one output. If combined with 'stderr' at the root of the CWL document, that definition
+      will indicate the desired name of the output file where the error stream will be written to.  A random name will
+      be applied for the file of this output unless otherwise specified.
+    type: string
+    enum:
+      - stderr
+  CWLOutputStdErrObjectType:
+    type: object
+    properties:
+      type:
+        $ref: '#/$defs/CWLOutputStdErrDefinition'
+    required:
+      - type
+  CWLOutputStdErr:
+    oneOf:
+      - $ref: '#/$defs/CWLOutputStdErrDefinition'
+      - $ref: '#/$defs/CWLOutputStdErrObjectType'
+  CWLInputsDefinition:
+    oneOf:
+    - $ref: '#/$defs/CWLInputList'
+    - $comment: Avoid 'oneOf' conflict of generic mapping key strings as input identifier matching against '$import'.
+      allOf:
+        - $ref: '#/$defs/CWLInputMap'
+        - not:
+            $ref: '#/$defs/CWLImport'
+    - $ref: '#/$defs/CWLImport'
+    title: CWLInputsDefinition
+    description: All inputs available to the Application Package.
+  CWLInputList:
+    type: array
+    title: CWLInputList
+    description: Package inputs defined as items.
+    items:
+      $ref: '#/$defs/CWLInputItem'
+  CWLFormat:
+    oneOf:
+      - $ref: '#/$defs/CWLExpression'
+      - type: array
+        items:
+          $ref: '#/$defs/CWLExpression'
+  CWLType:
+    oneOf:
+    - $ref: '#/$defs/CWLTypeBase'
+    - $ref: '#/$defs/CWLTypeList'
+    title: CWL Type
+  CWLTypeDefinition:
+    type: string
+    title: CWL type string definition
+    summary: CWL type string definition.
+    description: Field type definition.
+    enum:
+      - 'null'
+      - Any
+      - Any[]
+      - Directory
+      - Directory?
+      - Directory[]
+      - Directory[]?
+      - File
+      - File?
+      - File[]
+      - File[]?
+      - boolean
+      - boolean?
+      - boolean[]
+      - boolean[]?
+      - double
+      - double?
+      - double[]
+      - double[]?
+      - enum?
+      - enum[]
+      - enum[]?
+      - float
+      - float?
+      - float[]
+      - float[]?
+      - int
+      - int?
+      - int[]
+      - int[]?
+      - integer
+      - integer?
+      - integer[]
+      - integer[]?
+      - long
+      - long?
+      - long[]
+      - long[]?
+      - string
+      - string?
+      - string[]
+      - string[]?
+  CWLTypeBase:
+    oneOf:
+    - $ref: '#/$defs/CWLTypeDefinition'
+    - $ref: '#/$defs/CWLTypeArray'
+    - $ref: '#/$defs/CWLTypeEnum'
+    - $ref: '#/$defs/CWLTypeRecordRef'
+    - $ref: '#/$defs/CWLTypeRecordSchema'
+    title: CWLTypeBase
+  CWLTypeArray:
+    type: object
+    title: CWLTypeArray
+    summary: CWL type as list of items.
+    properties:
+      type:
+        type: string
+        title: type
+        example: array
+        enum:
+        - array
+      items:
+        $ref: '#/$defs/CWLType'
+    required:
+    - type
+    - items
+    additionalProperties: {}
+  CWLTypeSymbols:
+    type: array
+    title: CWLTypeSymbols
+    summary: Allowed values composing the enum.
+    items:
+      $ref: '#/$defs/CWLTypeSymbolValues'
+  CWLTypeSymbolValues:
+    oneOf:
+    - type: number
+    - type: string
+    title: CWLTypeSymbolValues
+  CWLTypeEnum:
+    type: object
+    title: CWLTypeEnum
+    summary: CWL type as enum of values.
+    properties:
+      type:
+        type: string
+        title: type
+        example: enum
+        enum:
+        - enum
+      symbols:
+        $ref: '#/$defs/CWLTypeSymbols'
+    required:
+    - type
+    - symbols
+    additionalProperties: {}
+  CWLTypeRecordRef:
+    description: |
+      An IRI with minimally a '{Record}' identifier to look for a schema definition locally or remotely.
+      
+      The identifier resolution is performed accordingly to the specified reference and as described in
+      https://www.commonwl.org/v1.2/SchemaSalad.html#Identifier_resolution.
+    $comment: Avoid 'oneOf' conflict of valid strings between this CWL record reference and the generic CWL types.
+    allOf:
+      - not:
+          $ref: '#/$defs/CWLTypeDefinition'
+      - not:
+          $ref: '#/$defs/CWLInputStdInDefinition'
+      - not:
+          $ref: '#/$defs/CWLOutputStdOutDefinition'
+      - not:
+          $ref: '#/$defs/CWLOutputStdErrDefinition'
+      - $ref: '#/$defs/CWLTypeRecordRefPattern'
+  CWLTypeRecordRefPattern:
+    type: string
+    format: url
+    pattern: '^(((?:http|ftp)s?:\/\/)?(?!.*\/\/.*$)(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+(?:[A-Za-z]{2,6}\.?|[A-Za-z0-9-]{2,}\.?)|localhost|\[[a-f0-9:]+\]|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::\d+)?(?:\/?|[\/?]\S+))?(?:[A-Za-z0-9\w\-.\/]+)?\#?[A-Za-z0-9\w\-.]+$'
+  CWLTypeList:
+    type: array
+    title: CWLTypeList
+    summary: Combination of allowed CWL types.
+    items:
+      $ref: '#/$defs/CWLTypeBase'
+  CWLDefault:
+    title: CWLDefault
+    description: Default value of input if not provided for task execution.
+    oneOf:
+    - $ref: '#/$defs/AnyLiteralType'
+    - $ref: '#/$defs/AnyLiteralList'
+    - $ref: '#/$defs/CWLDefaultLocation'
+    - $ref: '#/$defs/CWLDefaultObject'
+    - type: array
+      items:
+        $ref: '#/$defs/CWLDefaultObject'
+  CWLDefaultTypedConditional:
+    $comment: |
+      Validate that the 'default' value, if specified, is of same type as the CWL 'type'.
+      This avoids over-accepting anything that does not match the intended type.
+      However, validation limits itself to data literals and arrays.
+      Nested type and multi-type definitions will validate against 'Any'.
+    allOf:
+      - $comment: Object structure with minimally 'type' and 'default'. Otherwise, no point to continue testing.
+        type: object
+        properties:
+          type:
+            $ref: '#/$defs/AnyType'
+          default:
+            $ref: '#/$defs/AnyType'
+        required:
+          - type
+      - $comment: Explicit null.
+        if:
+          properties:
+            type:
+              const: 'null'
+        then:
+          properties:
+            default:
+              type: 'null'
+      - $comment: Required string.
+        if:
+          properties:
+            type:
+              const: string
+        then:
+          properties:
+            default:
+              type: string
+      - $comment: Optional string.
+        if:
+          properties:
+            type:
+              const: string?
+        then:
+          properties:
+            default:
+              type:
+              - string
+              - 'null'
+      - $comment: Required boolean.
+        if:
+          properties:
+            type:
+              const: boolean
+        then:
+          properties:
+            default:
+              type: boolean
+      - $comment: Optional boolean.
+        if:
+          properties:
+            type:
+              enum:
+                - double?
+                - float?
+                - int?
+                - integer?
+                - long?
+        then:
+          properties:
+            default:
+              type:
+              - number
+              - 'null'
+      - $comment: Required numeric.
+        if:
+          properties:
+            type:
+              enum:
+                - double
+                - float
+                - int
+                - integer
+                - long
+        then:
+          properties:
+            default:
+              type: number
+      - $comment: Optional numeric.
+        if:
+          properties:
+            type:
+              enum:
+                - double?
+                - float?
+                - int?
+                - integer?
+                - long?
+        then:
+          properties:
+            default:
+              type:
+              - number
+              - 'null'
+      - $comment: Required enum.
+        if:
+          properties:
+            type:
+              const: enum
+            symbols:
+              $ref: '#/$defs/CWLTypeSymbols'
+        then:
+          properties:
+            default:
+              type:
+                $ref: '#/$defs/CWLTypeSymbolValues'
+      - $comment: Optional enum.
+        if:
+          properties:
+            type:
+              const: enum?
+            symbols:
+              $ref: '#/$defs/CWLTypeSymbols'
+        then:
+          properties:
+            default:
+              oneOf:
+                - $ref: '#/$defs/CWLTypeSymbolValues'
+                - type: 'null'
+      - $comment: Required File or Directory.
+        if:
+          properties:
+            type:
+              enum:
+              - Directory
+              - File
+        then:
+          properties:
+            default:
+              $ref: '#/$defs/CWLDefaultLocation'
+      - $comment: Optional File or Directory.
+        if:
+          properties:
+            type:
+              enum:
+              - Directory?
+              - File?
+        then:
+          properties:
+            default:
+              oneOf:
+              - $ref: '#/$defs/CWLDefaultLocation'
+              - type: 'null'
+      - $comment: Required array of string.
+        if:
+          oneOf:
+          - properties:
+              type:
+                const: string[]
+          - properties:
+              type:
+                const: array
+              items:
+                const: string
+        then:
+          properties:
+            default:
+              type: array
+              items:
+                type: string
+      - $comment: Required array of boolean.
+        if:
+          oneOf:
+          - properties:
+              type:
+                const: boolean[]
+          - properties:
+              type:
+                const: array
+              items:
+                const: boolean
+        then:
+          properties:
+            default:
+              type: array
+              items:
+                type: boolean
+      - $comment: Required array of numeric.
+        if:
+          oneOf:
+            - properties:
+                type:
+                  enum:
+                  - double[]
+                  - float[]
+                  - int[]
+                  - integer[]
+                  - long[]
+            - properties:
+                type:
+                  const: array
+                items:
+                  enum:
+                    - double
+                    - float
+                    - int
+                    - integer
+                    - long
+        then:
+          properties:
+            default:
+              type: array
+              items:
+                type: number
+      - $comment: Required anything (single).
+        if:
+          properties:
+            type:
+              const: Any
+        then:
+          properties:
+            default:
+              $comment: Match anything.
+              $ref: '#/$defs/AnyType'
+      - $comment: Required array of anything.
+        if:
+          properties:
+            type:
+              const: Any[]
+        then:
+          properties:
+            default:
+              $comment: Match anything as long as under array.
+              type: array
+              items:
+                $ref: '#/$defs/AnyType'
+  AnyType:
+    type:
+      - boolean
+      - number
+      - string
+      - array
+      - object
+  AnyLiteralType:
+    oneOf:
+      - type: number
+      - type: boolean
+      - type: string
+  AnyLiteralList:
+    type: array
+    title: AnyLiteralList
+    items:
+      $ref: '#/$defs/AnyLiteralType'
+  Checksum:
+    $comment: |
+      Minimal pattern check to know which hash algorithm to apply,
+      but don't check too harshly for the rest (length, allowed characters, etc.).
+    type: string
+    pattern: '^[a-z0-9\-]+\$[\w\-.]+$'
+  ReferenceURL:
+    type: string
+    format: url
+    pattern: '^((?:http|ftp)s?:\/\/)?(?!.*\/\/.*$)(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+(?:[A-Za-z]{2,6}\.?|[A-Za-z0-9-]{2,}\.?)|localhost|\[[a-f0-9:]+\]|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::\d+)?(?:\/?|[/?]\S+)$'
+  CWLDefaultLocation:
+    type: object
+    properties:
+      class:
+        type: string
+        enum:
+          - File
+          - Directory
+      path:
+        type: string
+      location:
+        type: string
+      basename:
+        type: string
+      nameroot:
+        type: string
+    required:
+      - class
+    oneOf:
+    - required:
+      - path
+    - required:
+      - location
+    additionalProperties: false
+  CWLDefaultObject:
+    type: object
+    not:
+      $comment: Avoid false-positive match of default File or Directory location definition.
+      properties:
+        class:
+          type: string
+          enum:
+            - File
+            - Directory
+    additionalProperties: {}
+  InputBinding:
+    type: object
+    title: Input Binding
+    description: Defines how to specify the input for the command.
+    properties:
+      prefix:
+        type: string
+      position:
+        oneOf:
+        - type: integer
+        - $ref: '#/$defs/CWLExpression'
+      valueFrom:
+        $ref: '#/$defs/CWLExpression'
+      itemSeparator:
+        type: string
+      shellQuote:
+        type: boolean
+    additionalProperties: false
+  CWLInputItemBase:
+    type: object
+    properties:
+      type:
+        oneOf:
+          - $ref: '#/$defs/CWLType'
+          - $ref: '#/$defs/CWLInputStdIn'
+      inputBinding:
+        $ref: '#/$defs/InputBinding'
+      id:
+        description: Identifier of the CWL input.
+        $ref: '#/$defs/CWLIdentifier'
+    required:
+      - type
+      - id
+    additionalProperties: { }
+  CWLInputItem:
+    title: Input
+    description: |
+      Input specification. Note that multiple formats are supported and
+      not all specification variants or parameters are presented here. Please refer
+      to official CWL documentation for more details (https://www.commonwl.org).
+    allOf:
+    - $ref: '#/$defs/CWLInputItemBase'
+    - $ref: '#/$defs/CWLDefaultTypedConditional'
+    - $ref: '#/$defs/CWLDocumentation'
+  CWLInputObjectBase:
+    type: object
+    properties:
+      type:
+        $ref: '#/$defs/CWLType'
+      inputBinding:
+        $ref: '#/$defs/InputBinding'
+        additionalProperties: { }
+    required:
+      - type
+    additionalProperties: { }
+  CWLInputObject:
+    title: CWLInputObject
+    summary: CWL type definition with parameters.
+    allOf:
+    - $ref: '#/$defs/CWLInputObjectBase'
+    - $ref: '#/$defs/CWLDefaultTypedConditional'
+    - $ref: '#/$defs/CWLDocumentation'
+  CWLInputMap:
+    type: object
+    title: CWLInputMap
+    description: Package inputs defined as mapping.
+    properties: {}
+    required: []
+    additionalProperties:
+      oneOf:
+      - $ref: '#/$defs/CWLType'
+      - $ref: '#/$defs/CWLInputObject'
+      - $ref: '#/$defs/CWLInputStdIn'
+      - $ref: '#/$defs/CWLImport'
+  CWLOutputsDefinition:
+    oneOf:
+    - $ref: '#/$defs/CWLOutputList'
+    - $comment: Avoid 'oneOf' conflict of generic mapping key strings as output identifier matching against '$import'.
+      allOf:
+      - $ref: '#/$defs/CWLOutputMap'
+      - not:
+          $ref: '#/$defs/CWLImport'
+    - $ref: '#/$defs/CWLImport'
+    title: CWLOutputsDefinition
+    description: All outputs produced by the Application Package.
+  CWLOutputList:
+    type: array
+    title: CWLOutputList
+    description: Package outputs defined as items.
+    items:
+      $ref: '#/$defs/CWLOutputItem'
+  OutputBinding:
+    type: object
+    title: OutputBinding
+    description: Defines how to retrieve the output result from the command.
+    properties:
+      glob:
+        description: Glob pattern to find the output on disk or mounted docker volume.
+        oneOf:
+        - $ref: '#/$defs/CWLExpression'
+        - type: array
+          items:
+            $ref: '#/$defs/CWLExpression'
+    additionalProperties: {}
+  CWLOutputItem:
+    type: object
+    title: CWLOutputItem
+    description: |
+      Output specification. Note that multiple formats are supported
+      and not all specification variants or parameters are presented here. Please
+      refer to official CWL documentation for more details (https://www.commonwl.org).
+    properties:
+      type:
+        oneOf:
+        - $ref: '#/$defs/CWLType'
+        - $ref: '#/$defs/CWLOutputStdOut'
+        - $ref: '#/$defs/CWLOutputStdErr'
+      outputBinding:
+        $ref: '#/$defs/OutputBinding'
+      id:
+        description: Identifier of the CWL output.
+        $ref: '#/$defs/CWLIdentifier'
+    required:
+    - type
+    - id
+    additionalProperties: {}
+  CWLOutputObjectBase:
+    type: object
+    title: CWLOutputObject
+    summary: CWL type definition with parameters.
+    properties:
+      type:
+        $ref: '#/$defs/CWLType'
+      outputBinding:
+        $ref: '#/$defs/OutputBinding'
+    required:
+    - type
+    additionalProperties: {}
+  CWLOutputObject:
+    allOf:
+      - $ref: '#/$defs/CWLDocumentation'
+      - $ref: '#/$defs/CWLOutputObjectBase'
+  CWLOutputMap:
+    type: object
+    title: CWLOutputMap
+    description: Package outputs defined as mapping.
+    properties: {}
+    required: []
+    additionalProperties:
+      oneOf:
+      - $ref: '#/$defs/CWLType'
+      - $ref: '#/$defs/CWLOutputObject'
+      - $ref: '#/$defs/CWLOutputStdOut'
+      - $ref: '#/$defs/CWLOutputStdErr'
+      - $ref: '#/$defs/CWLImport'
+  CWLScatter:
+    oneOf:
+    - $ref: '#/$defs/CWLIdentifier'
+    - $ref: '#/$defs/CWLScatterMulti'
+    title: CWLScatter
+    description: |
+      One or more input identifier of an application step within a Workflow
+      were an array-based input to that Workflow should be scattered across multiple
+      instances of the step application.
+  CWLScatterMulti:
+    type: array
+    title: CWLScatterMulti
+    items:
+      $ref: '#/$defs/CWLIdentifier'
+  CWLScatterMethod:
+    type: string
+    title: scatterMethod
+    description: |
+      Describes how to decompose the scattered input into a discrete
+      set of jobs. When 'dotproduct', specifies that each of the input arrays
+      are aligned and one element taken from each array to construct each job.
+      It is an error if all input arrays are of different length. When 'nested_crossproduct',
+      specifies the Cartesian product of the inputs, producing a job for every
+      combination of the scattered inputs. The output must be nested arrays
+      for each level of scattering, in the order that the input arrays are listed
+      in the scatter field. When 'flat_crossproduct', specifies the Cartesian
+      product of the inputs, producing a job for every combination of the scattered
+      inputs. The output arrays must be flattened to a single level, but otherwise
+      listed in the order that the input arrays are listed in the scatter field.
+    enum:
+      - dotproduct
+      - nested_crossproduct
+      - flat_crossproduct
+  CWLWorkflowStepScatter:
+    type: object
+    properties:
+      scatter:
+        $ref: '#/$defs/Scatter'
+      scatterMethod:
+        $ref: '#/$defs/ScatterMethod'
+  CWLWorkflowStepRun:
+    description: Nested CWL definition to run as Workflow step.
+    oneOf:
+      - description: File or URL reference to a CWL tool definition.
+        type: string
+      - description: Nested CWL tool definition for the step.
+        $ref: '#/$defs/CWLAtomicNested'
+      - description: Nested CWL Workflow definition for the step.
+        $ref: '#/$defs/CWLWorkflowNested'
+  CWLWorkflowStepWhen:
+    description: Condition to execute a step that must evaluate to a boolean-like value.
+    $ref: '#/$defs/CWLExpression'
+  LinkMergeMethod:
+    type: string
+    enum:
+      - merge_nested
+      - merge_flattened
+  CWLWorkflowStepInputBase:
+    type: object
+    properties:
+      source:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+      linkMerge:
+        $ref: '#/$defs/LinkMergeMethod'
+      valueFrom:
+        $ref: '#/$defs/CWLExpression'
+  CWLWorkflowStepInputDefault:
+    $comment: |
+      CWL 'type' is not specified at this level for step inputs
+      (it is provided by the mapped input of the nested tool instead).
+      Therefore, cannot validate against 'CWLDefaultTypedConditional'.
+    type: object
+    properties:
+      default:
+        $ref: '#/$defs/CWLDefault'
+  CWLWorkflowStepInput:
+    allOf:
+      - $ref: '#/$defs/CWLWorkflowStepInputBase'
+      - $ref: '#/$defs/CWLWorkflowStepInputDefault'
+  CWLWorkflowStepInputId:
+    type: object
+    properties:
+      id:
+        $ref: '#/$defs/CWLIdentifier'
+    required:
+      - id
+  CWLWorkflowStepInItem:
+    allOf:
+      - $ref: '#/$defs/CWLWorkflowStepInputId'
+      - $ref: '#/$defs/CWLWorkflowStepInputBase'
+      - $ref: '#/$defs/CWLWorkflowStepInputDefault'
+  CWLWorkflowStepInList:
+    type: array
+    items:
+      $ref: '#/$defs/CWLWorkflowStepInItem'
+  CWLWorkflowStepInMap:
+    type: object
+    additionalProperties:
+      oneOf:
+        - type: string
+        - type: array
+          items:
+            type: string
+        - $ref: '#/$defs/CWLWorkflowStepInput'
+  CWLWorkflowStepIn:
+    description: Mapping of Workflow step inputs to nested CWL tool definitions inputs or outputs.
+    oneOf:
+      - $ref: '#/$defs/CWLWorkflowStepInMap'
+      - $ref: '#/$defs/CWLWorkflowStepInList'
+  CWLWorkflowStepOutId:
+    type: object
+    properties:
+      id:
+        $ref: '#/$defs/CWLIdentifier'
+    required:
+      - id
+    additionalProperties: false
+  CWLWorkflowStepOut:
+    description: Mapping of Workflow step inputs to nested CWL tool definitions inputs or outputs.
+    type: array
+    items:
+      oneOf:
+        - $ref: '#/$defs/CWLIdentifier'
+        - $ref: '#/$defs/CWLWorkflowStepOutId'
+  CWLWorkflowStepDefinition:
+    type: object
+    properties:
+      in:
+        $ref: '#/$defs/CWLWorkflowStepIn'
+      run:
+        $ref: '#/$defs/CWLWorkflowStepRun'
+      when:
+        $ref: '#/$defs/CWLWorkflowStepWhen'
+      out:
+        $ref: '#/$defs/CWLWorkflowStepOut'
+    required:
+      - in
+      - run
+      - out
+  CWLWorkflowStepObject:
+    allOf:
+    - $ref: '#/$defs/CWLWorkflowStepDefinition'
+    - $ref: '#/$defs/CWLWorkflowStepScatter'
+  CWLWorkflowStepItem:
+    allOf:
+      - $ref: '#/$defs/CWLWorkflowStepId'
+      - $ref: '#/$defs/CWLWorkflowStepObject'
+  CWLWorkflowStepId:
+    type: object
+    properties:
+      id:
+        $ref: '#/$defs/CWLIdentifier'
+    required:
+      - id
+  CWLWorkflowStepMap:
+    type: object
+    additionalProperties:
+      $ref: '#/$defs/CWLWorkflowStepObject'
+  CWLWorkflowStepList:
+    type: array
+    items:
+      $ref: '#/$defs/CWLWorkflowStepItem'
+  CWLWorkflowClass:
+    type: object
+    properties:
+      class:
+        type: string
+        enum:
+          - Workflow
+  CWLWorkflowSteps:
+    oneOf:
+      - $ref: '#/$defs/CWLWorkflowStepMap'
+      - $ref: '#/$defs/CWLWorkflowStepList'
+  CWLWorkflowBase:
+    type: object
+    properties:
+      steps:
+        $ref: '#/$defs/CWLWorkflowSteps'
+      inputs:
+        $ref: '#/$defs/CWLInputsDefinition'
+      outputs:
+        $ref: '#/$defs/CWLOutputsDefinition'
+      requirements:
+        $comment: Technically a different subset, but lots of redefinitions to be done.
+        $ref: '#/$defs/CWLRequirements'
+      hints:
+        $comment: Technically a different subset, but lots of redefinitions to be done.
+        $ref: '#/$defs/CWLHints'
+  CWLWorkflowNested:
+    $comment: Same as 'CWLWorkflow', but 'cwlVersion' not repeated (only at root).
+    allOf:
+      - $ref: '#/$defs/CWLMetadata'
+      - $ref: '#/$defs/CWLDocumentation'
+      - $ref: '#/$defs/CWLWorkflowClass'
+      - $ref: '#/$defs/CWLWorkflowBase'
+  CWLWorkflow:
+    allOf:
+      - $ref: '#/$defs/CWLVersion'
+      - $ref: '#/$defs/CWLMetadata'
+      - $ref: '#/$defs/CWLDocumentation'
+      - $ref: '#/$defs/CWLWorkflowClass'
+      - $ref: '#/$defs/CWLWorkflowBase'
+  CWLVersion:
+    type: object
+    properties:
+      clwVersion:
+        type: string
+        title: cwlVersion
+        description: CWL version of the described application package.
+        pattern: '^v\d+(\.\d+(\.\d+)*)*$'
+    required:
+      - cwlVersion
+  CWLAtomic:
+    allOf:
+      - $ref: '#/$defs/CWLVersion'
+      - $ref: '#/$defs/CWLMetadata'
+      - $ref: '#/$defs/CWLDocumentation'
+      - $ref: '#/$defs/CWLAtomicBase'
+  CWLAtomicNested:
+    $comment: Same as 'CWLAtomic', but 'cwlVersion' not repeated (only at root).
+    allOf:
+    - $ref: '#/$defs/CWLMetadata'
+    - $ref: '#/$defs/CWLDocumentation'
+    - $ref: '#/$defs/CWLAtomicBase'
+  CWLAtomicBase:
+    type: object
+    title: CWL atomic definition
+    description: Direct CWL definition instead of the graph representation.
+    properties:
+      id:
+        $ref: '#/$defs/CWLIdentifier'
+      class:
+        type: string
+        title: Class
+        description: CWL class specification. This is used to differentiate between
+          single Application Package (AP)definitions and Workflow that chains multiple
+          packages.
+        enum:
+        - CommandLineTool
+        - ExpressionTool
+      intent:
+        $ref: '#/$defs/CWLIntent'
+      requirements:
+        $ref: '#/$defs/CWLRequirements'
+      hints:
+        $ref: '#/$defs/CWLHints'
+      baseCommand:
+        $ref: '#/$defs/CWLCommand'
+      arguments:
+        $ref: '#/$defs/CWLArguments'
+      inputs:
+        $ref: '#/$defs/CWLInputsDefinition'
+      outputs:
+        $ref: '#/$defs/CWLOutputsDefinition'
+      stdin:
+        description: |
+          Source of the input stream. 
+          Typically, an expression referring to an existing file name or an input of the CWL document.
+        $ref: '#/$defs/CWLExpression'
+      stdout:
+        description: |
+          Destination of the output stream.
+          Typically, an expression referring to a desired file name or provided by a CWL input reference.
+        $ref: '#/$defs/CWLExpression'
+      stderr:
+        description: |
+          Destination of the error stream.
+          Typically, an expression referring to a desired file name or provided by a CWL input reference.
+        $ref: '#/$defs/CWLExpression'
+      scatter:
+        $ref: '#/$defs/CWLScatter'
+      scatterMethod:
+        $ref: '#/$defs/CWLScatterMethod'
+    required:
+    - class
+    - inputs
+    - outputs
+  CWLGraphList:
+    type: array
+    title: CWLGraphList
+    description: Graph definition that defines *exactly one* CWL application package
+      represented as list. Multiple definitions simultaneously deployed is NOT supported
+      currently.
+    items:
+      $ref: '#/$defs/CWLGraphItem'
+    maxItems: 1
+    minItems: 1
+  CWLGraphItem:
+    allOf:
+      - $ref: '#/$defs/CWLMetadata'
+      - $ref: '#/$defs/CWLDocumentation'
+      - $ref: '#/$defs/CWLGraphItemBase'
+  CWLGraphItemBase:
+    type: object
+    title: CWLGraphItem
+    properties:
+      class:
+        type: string
+        title: Class
+        description: CWL class specification. This is used to differentiate between
+          single Application Package (AP)definitions and Workflow that chains multiple
+          packages.
+        enum:
+        - CommandLineTool
+        - ExpressionTool
+        - Workflow
+      id:
+        $ref: '#/$defs/CWLIdentifier'
+      intent:
+        $ref: '#/$defs/CWLIntent'
+      requirements:
+        $ref: '#/$defs/CWLRequirements'
+      hints:
+        $ref: '#/$defs/CWLHints'
+      baseCommand:
+        $ref: '#/$defs/CWLCommand'
+      arguments:
+        $ref: '#/$defs/CWLArguments'
+      inputs:
+        $ref: '#/$defs/CWLInputsDefinition'
+      outputs:
+        $ref: '#/$defs/CWLOutputsDefinition'
+      scatter:
+        $ref: '#/$defs/CWLScatter'
+      scatterMethod:
+        $ref: '#/$defs/CWLScatterMethod'
+    required:
+    - class
+    - id
+    - inputs
+    - outputs
+    additionalProperties: {}
+  CWLGraphBase:
+    type: object
+    properties:
+      $graph:
+        $ref: '#/$defs/CWLGraphList'
+    required:
+    - $graph
+    additionalProperties: {}
+  CWLGraph:
+    title: CWLGraph
+    allOf:
+      - $ref: '#/$defs/CWLVersion'
+      - $ref: '#/$defs/CWLMetadata'
+      - $ref: '#/$defs/CWLDocumentation'
+      - $ref: '#/$defs/CWLGraphBase'
+  CWLDocumentation:
+    type: object
+    properties:
+      label:
+        type: string
+      doc:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+  CWLMetadata:
+    type: object
+    properties:
+      s:keywords:
+        $ref: '#/$defs/CWLKeywordList'
+      version:
+        type: string
+        title: version
+        description: "Version of the process."
+        example: "1.2.3"
+        pattern: '^\d+(\.\d+(\.\d+(\.[A-Za-z0-9\-_]+)*)*)*$'

--- a/requirements-jsonschema-test.txt
+++ b/requirements-jsonschema-test.txt
@@ -1,0 +1,3 @@
+jsonschema
+pytest
+requests

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 func() {
-	helpmessage=$(cat)
+    helpmessage=$(cat)
 }
 func <<EOF
 $(basename "$0"): Run common workflow tool description language conformance tests.
@@ -64,15 +64,15 @@ do
         -n*)
             TEST_n=$arg
             ;;
-	-N*)
-	    TEST_N=$arg
-	    ;;
+        -N*)
+            TEST_N=$arg
+            ;;
         -s*)
             TEST_s=$arg
             ;;
-	-S*)
-	    TEST_S=$arg
-	    ;;
+        -S*)
+            TEST_S=$arg
+            ;;
         -j*)
             TEST_J=$arg
             ;;
@@ -150,10 +150,10 @@ runtest() {
 
     runs=$((runs+1))
     (COMMAND="cwltest --tool $1 \
-         --test=conformance_tests.yaml ${CLASS} \
-	 ${TEST_n} ${TEST_N} ${TEST_s} ${TEST_S} \
-         ${VERBOSE} ${TEST_L} ${TEST_J} ${ONLY_TOOLS} ${JUNIT_XML} \
-         ${TIMEOUT} ${BADGE} ${TAGS} -- ${EXTRA}"
+        --test=conformance_tests.yaml ${CLASS} \
+        ${TEST_n} ${TEST_N} ${TEST_s} ${TEST_S} \
+        ${VERBOSE} ${TEST_L} ${TEST_J} ${ONLY_TOOLS} ${JUNIT_XML} \
+        ${TIMEOUT} ${BADGE} ${TAGS} -- ${EXTRA}"
      if [ "$VERBOSE" = "--verbose" ]; then echo "${COMMAND}"; fi
      ${COMMAND}
     ) || failures=$((failures+1))
@@ -162,7 +162,7 @@ runtest() {
 if [ "$PLATFORM" = "Linux" ]; then
     runtest "$(readlink -f "$runner")"
 elif [ "$PLATFORM" = "Darwin" ]; then
-	runtest $runner
+    runtest $runner
 else
     runtest "$(greadlink -f "$runner")"
 fi

--- a/tests/json_schema/test_cwl_schema.py
+++ b/tests/json_schema/test_cwl_schema.py
@@ -1,0 +1,182 @@
+import logging
+import os
+import posixpath
+from functools import lru_cache
+from typing import Dict, List, Optional, Tuple, Type, TypedDict, Union, cast
+from typing_extensions import NotRequired, TypeAlias, TypeGuard
+from urllib.parse import urljoin, urlparse
+
+import jsonschema
+import requests
+import pytest
+from jsonschema.protocols import Validator
+from jsonschema.exceptions import ValidationError, best_match
+
+# WARNING: do not use 'pyyaml' (import yaml), it does invalid parsing of some scientific number representations
+# see 'Numbers in scientific notation without dot are parsed as string' (https://github.com/yaml/pyyaml/issues/173)
+# builtin 'json' and 'simplejson' also have this issue (https://github.com/common-workflow-language/cwl-v1.2/issues/252)
+from ruamel import yaml
+from ruamel.yaml.scanner import ScannerError
+
+# https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/1.2.1_proposed/conformance_tests.yaml
+CONFORMANCE_TESTS_FILE = os.path.join(os.path.dirname(__file__), "../../conformance_tests.yaml")
+# https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/1.2.1_proposed/json-schema/cwl.yaml
+CWL_JSON_SCHEMA_FILE = os.path.join(os.path.dirname(__file__), "../../json-schema/cwl.yaml")
+CWL_JSON_SCHEMA_REF = f"{CWL_JSON_SCHEMA_FILE}#/$defs/CWL"
+
+LOGGER = logging.getLogger(__name__)
+
+# pylint: disable=C0103,invalid-name
+Number = Union[int, float]
+ValueType = Union[str, Number, bool]
+AnyValueType = Optional[ValueType]
+# add more levels of explicit definitions than necessary to simulate JSON recursive structure better than 'Any'
+# amount of repeated equivalent definition makes typing analysis 'work well enough' for most use cases
+_JSON: TypeAlias = "JSON"
+_JsonObjectItemAlias: TypeAlias = "_JsonObjectItem"
+_JsonListItemAlias: TypeAlias = "_JsonListItem"
+_JsonObjectItem = Dict[str, Union[AnyValueType, _JSON, _JsonObjectItemAlias, _JsonListItemAlias]]
+_JsonListItem = List[Union[AnyValueType, _JSON, _JsonObjectItem, _JsonListItemAlias]]
+_JsonItem = Union[AnyValueType, _JSON, _JsonObjectItem, _JsonListItem]
+JSON = Union[Dict[str, Union[_JSON, _JsonItem]], List[Union[_JSON, _JsonItem]], AnyValueType]
+
+ConformanceTestDef = TypedDict(
+    "ConformanceTestDef",
+    {
+        "id": str,
+        "doc": str,
+        "tags": List[str],  # should contain 'json_schema_invalid' to XFAIL schema validation tests
+        "tool": str,
+        "job": NotRequired[str],  # not used, for running the actual CWL
+        "output": JSON,  # not used, output of CWL execution
+        "should_fail": NotRequired[bool],  # indicates failure as "execute failing", but potentially still valid CWL
+    }
+)
+
+
+@lru_cache(maxsize=None)
+def is_remote_file(file_location: str) -> TypeGuard[str]:
+    """
+    Parses to file location to figure out if it is remotely available or a local path.
+    """
+    cwl_file_path_or_url = file_location.replace("file://", "")
+    scheme = urlparse(cwl_file_path_or_url).scheme
+    return scheme != "" and not posixpath.ismount(f"{scheme}:")  # windows partition
+
+
+@lru_cache(maxsize=None)
+def load_file(file_path: str, text: bool = False) -> Union[JSON, str]:
+    """
+    Load :term:`JSON` or :term:`YAML` file contents from local path or remote URL.
+
+    If URL, get the content and validate it by loading, otherwise load file directly.
+
+    :param file_path: Local path or URL endpoint where file to load is located.
+    :param text: load contents as plain text rather than parsing it from :term:`JSON`/:term:`YAML`.
+    :returns: loaded contents either parsed and converted to Python objects or as plain text.
+    :raises ValueError: if YAML or JSON cannot be parsed or loaded from location.
+    """
+    try:
+        if is_remote_file(file_path):
+            headers = {"Accept": "text/plain"}
+            resp = requests.get(file_path, headers=headers)
+            if resp.status_code != 200:
+                raise ValueError("Loading error: [%s]", file_path)
+            return resp.content if text else yaml.safe_load(resp.content)
+        with open(file_path, mode="r", encoding="utf-8") as f:
+            return f.read() if text else yaml.safe_load(f)
+    except OSError as exc:
+        LOGGER.debug("Loading error: %s", exc, exc_info=exc)
+        raise
+    except ScannerError as exc:  # pragma: no cover
+        LOGGER.debug("Parsing error: %s", exc, exc_info=exc)
+        raise ValueError("Failed parsing file content as JSON or YAML.")
+
+
+def resolve_ref(schema_file: str) -> Tuple[str, JSON, JSON]:
+    schema_path = []
+    if "#" in schema_file:
+        schema_file, schema_ref = schema_file.split("#", 1)
+        schema_path = [ref for ref in schema_ref.split("/") if ref]
+    schema_base = schema = load_file(schema_file)
+    if schema_path:
+        for part in schema_path:
+            schema = schema[part]
+    # ensure local schema can find relative $ref, since the provided reference can be a sub-schema (with "#/...")
+    schema_uri = f"file://{schema_file}" if schema_file.startswith("/") else schema_file
+    return schema_uri, schema_base, schema
+
+
+def load_conformance_tests(test_file: str) -> List[ConformanceTestDef]:
+    conformance_tests = load_file(test_file)
+    assert isinstance(conformance_tests, list)
+    assert all(isinstance(conf_test, dict) for conf_test in conformance_tests)
+    test_base = os.path.dirname(test_file)
+    all_conf_test = []
+    for conf_test in conformance_tests:
+        if "$import" in conf_test:
+            conf_path = urljoin(f"{test_base}/", conf_test["$import"])
+            conf_test = load_conformance_tests(conf_path)
+            all_conf_test.extend(conf_test)
+            continue
+        for ref in ["job", "tool"]:
+            if ref not in conf_test:
+                continue
+            if not urlparse(conf_test[ref]).scheme:
+                conf_test[ref] = urljoin(f"{test_base}/", conf_test[ref])
+        conf_test.setdefault("doc", "<undefined>")
+        all_conf_test.append(conf_test)
+    return all_conf_test
+
+
+@pytest.mark.parametrize(
+    "conformance_test",
+    load_conformance_tests(CONFORMANCE_TESTS_FILE)
+)
+def test_conformance(conformance_test: ConformanceTestDef, request: pytest.FixtureRequest) -> None:
+    LOGGER.debug(
+        "Testing [%s] (%s) with [%s]",
+        conformance_test["id"],
+        conformance_test["doc"],
+        conformance_test["tool"],
+    )
+
+    # if the tool CWL is a '$graph' with a reference in the IRI (tool-path.cwl#nested), ignore the nested reference
+    # this is because the main 'CWL' JSON schema expect 'cwlVersion' at the root of all documents
+    # if we test the nested tool directly against 'CWL', JSON schema will fail immediately
+    # also, we evaluate more test cases if we always consider the full sample tool
+    instance_file = conformance_test["tool"].rsplit("#")[0]
+    instance = load_file(instance_file)
+    instance_xfail = "json_schema_invalid" in conformance_test.get("tags", [])
+    request.applymarker(pytest.mark.xfail(reason="Test tagged with 'json_schema_invalid'.", condition=instance_xfail))
+
+    schema_uri, schema_base, schema_test = resolve_ref(CWL_JSON_SCHEMA_REF)
+    validator: Type[Validator] = jsonschema.validators.validator_for(schema_base)
+    validator.resolver = jsonschema.RefResolver(base_uri=schema_uri, referrer=schema_base)
+
+    try:
+        # similar to 'validate()' call that raises directly, but obtain the error for more context
+        # useful to get more context for 'oneOf' cases that only show "is not valid under any of the given schemas"
+        schema_validator = validator(schema_base).evolve(schema=schema_test)
+        errors = list(schema_validator.iter_errors(instance))
+        if errors:
+            if len(errors) == 1 and "oneOf" in errors[0].schema:
+                error = errors[0]
+                error.message += "\n\nFor each case under oneOf:\n" + "\n".join(
+                    f"- {err.message}"
+                    if not err.message.endswith("is not valid under any of the given schemas")
+                    else f"- all invalid under oneOf {err.validator_value}"
+                    for err in error.context
+                )
+                raise error
+            main_error = cast(
+                ValidationError,
+                best_match(errors),  # what 'validate()' normally does using 'iter_errors()'
+            )
+            raise main_error
+    except Exception as exc:
+        test_id = conformance_test["id"]
+        test_doc = conformance_test["doc"]
+        raise AssertionError(
+            f"Failed [{test_id}] ({instance_file}) tool validation for [{test_doc}]."
+        ) from exc

--- a/tests/loadContents/test-index.yaml
+++ b/tests/loadContents/test-index.yaml
@@ -11,4 +11,4 @@
   output: {}
   doc: "Test that loadContents on a file larger than 64k fails"
   should_fail: true
-  tags: [ command_line_tool, required ]
+  tags: [ command_line_tool, required, json_schema_invalid ]

--- a/tests/mixed-versions/test-index.yaml
+++ b/tests/mixed-versions/test-index.yaml
@@ -30,14 +30,14 @@
   id: invalid_syntax_v10_uses_v12_tool
   doc: test tool with v1.2 syntax marked as v1.0 (should fail)
   should_fail: true
-  tags: [ command_line_tool ]
+  tags: [ command_line_tool, json_schema_invalid ]
 
 - job: null
   tool: invalid-tool-v11.cwl
   doc: test tool with v1.2 syntax marked as v1.1 (should fail)
   id: invalid_syntax_v11_uses_v12_tool
   should_fail: true
-  tags: [ command_line_tool ]
+  tags: [ command_line_tool, json_schema_invalid ]
 
 - job: null
   tool: invalid-wf-v10.cwl


### PR DESCRIPTION
## Changes
- Adds CWL JSON schema
- Adds test suite to GitHub Actions CI with pytest to validate the JSON schema against conformance test items
- Fix minor indentation issues in `run_test.sh`

## References
- Closes https://github.com/common-workflow-language/cwl-v1.2/issues/253
- Closes https://github.com/common-workflow-language/cwl-v1.2/issues/251 (2 failing test cases)
- Relates to https://github.com/opengeospatial/ogcapi-processes/pull/327
- Relates to https://github.com/opengeospatial/ogcapi-processes/pull/329