### PR TITLE
Move `CWLInputFile` definition out of Base.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: schema-salad-tool salad/schema_salad/metaschema/metaschema.yml CommonWorkflowLanguage.yml
       
       - name: Download schema for conformance_tests.yaml
-        run: curl -LO https://raw.githubusercontent.com/common-workflow-language/cwltest/main/cwltest/cwltest-schema.yml
+        run: curl -LO https://raw.githubusercontent.com/common-workflow-language/cwltest/main/src/cwltest/cwltest-schema.yml
       
       - name: Validate conformance_tests.yaml
         run: schema-salad-tool cwltest-schema.yml conformance_tests.yaml

--- a/Base.yml
+++ b/Base.yml
@@ -482,17 +482,3 @@ $graph:
     Generic type representing a valid CWL object. It is used to represent
     `default` values passed to CWL `InputParameter` and `WorkflowStepInput`
     record fields.
-
-- name: CWLInputFile
-  type: map
-  values:
-   - "null"
-   - type: array
-     items: ProcessRequirement
-   - CWLObjectType
-  doc: |
-    Type representing a valid CWL input file as a `map<string, union<array<ProcessRequirement>, CWLObjectType>>`.
-  jsonldPredicate:
-    _id: "cwl:inputfile"
-    _container: "@list"
-    noLinkCheck: true

--- a/CONFORMANCE_TESTS.md
+++ b/CONFORMANCE_TESTS.md
@@ -118,7 +118,7 @@ and the expected outputs (or `should_fail: true` if the test is deliberately bro
 They are stored in [`conformance_tests.yaml`](https://github.com/common-workflow-language/cwl-v1.2/blob/main/conformance_tests.yaml)
 (or a file `$import`ed into that one)
 
-You can examine [the formal schema of this file](https://github.com/common-workflow-language/cwltest/blob/main/cwltest/cwltest-schema.yml),
+You can examine [the formal schema of this file](https://github.com/common-workflow-language/cwltest/blob/main/src/cwltest/cwltest-schema.yml),
 or just continue reading here for an explanation.
 
 The conformance test file is a YAML document: a list of key-value pairs.

--- a/CommonWorkflowLanguage.yml
+++ b/CommonWorkflowLanguage.yml
@@ -10,3 +10,17 @@ $graph:
 - $import: Process.yml
 - $import: CommandLineTool.yml
 - $import: Workflow.yml
+
+- name: CWLInputFile
+  type: map
+  values:
+   - "null"
+   - type: array
+     items: ProcessRequirement
+   - CWLObjectType
+  doc: |
+    Type representing a valid CWL input file as a `map<string, union<array<ProcessRequirement>, CWLObjectType>>`.
+  jsonldPredicate:
+    _id: "cwl:inputfile"
+    _container: "@list"
+    noLinkCheck: true


### PR DESCRIPTION
`CWLInputFile` references `ProcessRequirement`, which is declared in Process.yml and imported after Base.yml. This caused `ProcessRequirement` to be used before it was declared. Move the definition to CommonWorkflowLanguage.yml, after all imports are in place.