### PR TITLE
Add named unions for input/output parameter types

### DIFF
--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -650,75 +650,6 @@ $graph:
     - specializeFrom: OutputArraySchema
       specializeTo: CommandOutputArraySchema
 
-
-- type: record
-  name: CommandInputParameter
-  extends: InputParameter
-  doc: An input parameter for a CommandLineTool.
-  fields:
-    - name: type
-      type:
-        - CWLType
-        - stdin
-        - CommandInputRecordSchema
-        - CommandInputEnumSchema
-        - CommandInputArraySchema
-        - string
-        - type: array
-          items:
-            - CWLType
-            - CommandInputRecordSchema
-            - CommandInputEnumSchema
-            - CommandInputArraySchema
-            - string
-      jsonldPredicate:
-        "_id": "sld:type"
-        "_type": "@vocab"
-        refScope: 2
-        typeDSL: True
-      doc: |
-        Specify valid types of data that may be assigned to this parameter.
-    - name: inputBinding
-      type: CommandLineBinding?
-      doc: |
-        Describes how to turn the input parameters of a process into
-        command line arguments.
-      jsonldPredicate: "cwl:inputBinding"
-
-- type: record
-  name: CommandOutputParameter
-  extends: OutputParameter
-  doc: An output parameter for a CommandLineTool.
-  fields:
-    - name: type
-      type:
-        - CWLType
-        - stdout
-        - stderr
-        - CommandOutputRecordSchema
-        - CommandOutputEnumSchema
-        - CommandOutputArraySchema
-        - string
-        - type: array
-          items:
-            - CWLType
-            - CommandOutputRecordSchema
-            - CommandOutputEnumSchema
-            - CommandOutputArraySchema
-            - string
-      jsonldPredicate:
-        "_id": "sld:type"
-        "_type": "@vocab"
-        refScope: 2
-        typeDSL: True
-      doc: |
-        Specify valid types of data that may be assigned to this parameter.
-    - name: outputBinding
-      type: CommandOutputBinding?
-      jsonldPredicate: "cwl:outputBinding"
-      doc: Describes how to generate this output object based on the files
-        produced by a CommandLineTool
-
 - name: stdin
   type: enum
   symbols: [ "cwl:stdin" ]
@@ -795,7 +726,6 @@ $graph:
     (e.g. `echo a && echo b`) `stdout` must include the output of
     every command.
 
-
 - name: stderr
   type: enum
   symbols: [ "cwl:stderr" ]
@@ -843,6 +773,85 @@ $graph:
     stderr: random_stderr_filenameABCDEFG
     ```
 
+- name: CommandInputParameterType
+  type: union
+  names:
+    - CWLType
+    - stdin
+    - CommandInputRecordSchema
+    - CommandInputEnumSchema
+    - CommandInputArraySchema
+    - string
+    - type: array
+      items:
+        - CWLType
+        - CommandInputRecordSchema
+        - CommandInputEnumSchema
+        - CommandInputArraySchema
+        - string
+  doc: |
+    Type schema for the CWL `CommandInputParameter` class.
+
+- type: record
+  name: CommandInputParameter
+  extends: InputParameter
+  doc: An input parameter for a CommandLineTool.
+  fields:
+    - name: type
+      type: CommandInputParameterType
+      jsonldPredicate:
+        "_id": "sld:type"
+        "_type": "@vocab"
+        refScope: 2
+        typeDSL: True
+      doc: |
+        Specify valid types of data that may be assigned to this parameter.
+    - name: inputBinding
+      type: CommandLineBinding?
+      doc: |
+        Describes how to turn the input parameters of a process into
+        command line arguments.
+      jsonldPredicate: "cwl:inputBinding"
+
+- name: CommandOutputParameterType
+  type: union
+  names:
+    - CWLType
+    - stdout
+    - stderr
+    - CommandOutputRecordSchema
+    - CommandOutputEnumSchema
+    - CommandOutputArraySchema
+    - string
+    - type: array
+      items:
+        - CWLType
+        - CommandOutputRecordSchema
+        - CommandOutputEnumSchema
+        - CommandOutputArraySchema
+        - string
+  doc: |
+    Type schema for the CWL `CommandInputParameter` class.
+
+- type: record
+  name: CommandOutputParameter
+  extends: OutputParameter
+  doc: An output parameter for a CommandLineTool.
+  fields:
+    - name: type
+      type: CommandOutputParameterType
+      jsonldPredicate:
+        "_id": "sld:type"
+        "_type": "@vocab"
+        refScope: 2
+        typeDSL: True
+      doc: |
+        Specify valid types of data that may be assigned to this parameter.
+    - name: outputBinding
+      type: CommandOutputBinding?
+      jsonldPredicate: "cwl:outputBinding"
+      doc: Describes how to generate this output object based on the files
+        produced by a CommandLineTool
 
 - type: record
   name: CommandLineTool

--- a/Operation.yml
+++ b/Operation.yml
@@ -14,19 +14,7 @@ $graph:
     Describe an input parameter of an operation.
   fields:
     - name: type
-      type:
-        - CWLType
-        - InputRecordSchema
-        - InputEnumSchema
-        - InputArraySchema
-        - string
-        - type: array
-          items:
-            - CWLType
-            - InputRecordSchema
-            - InputEnumSchema
-            - InputArraySchema
-            - string
+      type: InputParameterType
       jsonldPredicate:
         "_id": "sld:type"
         "_type": "@vocab"
@@ -43,19 +31,7 @@ $graph:
     Describe an output parameter of an operation.
   fields:
     - name: type
-      type:
-        - CWLType
-        - OutputRecordSchema
-        - OutputEnumSchema
-        - OutputArraySchema
-        - string
-        - type: array
-          items:
-            - CWLType
-            - OutputRecordSchema
-            - OutputEnumSchema
-            - OutputArraySchema
-            - string
+      type: OutputParameterType
       jsonldPredicate:
         "_id": "sld:type"
         "_type": "@vocab"

--- a/Process.yml
+++ b/Process.yml
@@ -320,6 +320,24 @@ $graph:
     - specializeFrom: "sld:PrimitiveType"
       specializeTo: CWLType
 
+- name: InputParameterType
+  type: union
+  names:
+    - CWLType
+    - InputRecordSchema
+    - InputEnumSchema
+    - InputArraySchema
+    - string
+    - type: array
+      items:
+        - CWLType
+        - InputRecordSchema
+        - InputEnumSchema
+        - InputArraySchema
+        - string
+  doc: |
+    Type schema for the CWL `WorkflowInputParameter` and
+    `OperationInputParameter` classes.
 
 - name: OutputRecordField
   type: record
@@ -364,6 +382,24 @@ $graph:
     - specializeFrom: "sld:PrimitiveType"
       specializeTo: CWLType
 
+- name: OutputParameterType
+  type: union
+  names:
+    - CWLType
+    - OutputRecordSchema
+    - OutputEnumSchema
+    - OutputArraySchema
+    - string
+    - type: array
+      items:
+        - CWLType
+        - OutputRecordSchema
+        - OutputEnumSchema
+        - OutputArraySchema
+        - string
+  doc: |
+    Type schema for the CWL `WorkflowOutputParameter` and
+    `OperationOutputParameter` classes.
 
 - name: InputParameter
   type: record

--- a/Workflow.yml
+++ b/Workflow.yml
@@ -294,19 +294,7 @@ $graph:
   docParent: "#Workflow"
   fields:
     - name: type
-      type:
-        - CWLType
-        - InputRecordSchema
-        - InputEnumSchema
-        - InputArraySchema
-        - string
-        - type: array
-          items:
-            - CWLType
-            - InputRecordSchema
-            - InputEnumSchema
-            - InputArraySchema
-            - string
+      type: InputParameterType
       jsonldPredicate:
         "_id": "sld:type"
         "_type": "@vocab"
@@ -418,19 +406,7 @@ $graph:
         The method to use to choose non-null elements among multiple sources.
 
     - name: type
-      type:
-        - CWLType
-        - OutputRecordSchema
-        - OutputEnumSchema
-        - OutputArraySchema
-        - string
-        - type: array
-          items:
-            - CWLType
-            - OutputRecordSchema
-            - OutputEnumSchema
-            - OutputArraySchema
-            - string
+      type: OutputParameterType
       jsonldPredicate:
         "_id": "sld:type"
         "_type": "@vocab"

--- a/extensions.yml
+++ b/extensions.yml
@@ -3,7 +3,7 @@ $namespaces:
   cwl: "https://w3id.org/cwl/cwl#"
   cwltool: "http://commonwl.org/cwltool#"
 $graph:
-- $import: https://github.com/common-workflow-language/cwl-v1.2/raw/codegen/CommonWorkflowLanguage.yml
+- $import: CommonWorkflowLanguage.yml
 
 - name: Secrets
   type: record


### PR DESCRIPTION
Introduce named union types for the `type` field of input and output parameters:
- `InputParameterType` and `OutputParameterType` (Process.yml), used by Workflow.yml and Operation.yml
- `CommandInputParameterType` and `CommandOutputParameterType` (CommandLineTool.yml)

Move the `stdin`, `stdout`, and `stderr` enum definitions before `CommandInputParameter` and `CommandOutputParameter` so they are declared before being used.

Import `CommonWorkflowLanguage.yml` locally in extensions.yml instead of from the raw GitHub URL.