### PR TITLE
Use `CWLOutputParameterType` for `ExpressionToolOutputParameter`

### DIFF
--- a/Workflow.yml
+++ b/Workflow.yml
@@ -264,19 +264,7 @@ $graph:
   extends: OutputParameter
   fields:
     - name: type
-      type:
-        - CWLType
-        - OutputRecordSchema
-        - OutputEnumSchema
-        - OutputArraySchema
-        - string
-        - type: array
-          items:
-            - CWLType
-            - OutputRecordSchema
-            - OutputEnumSchema
-            - OutputArraySchema
-            - string
+      type: OutputParameterType
       jsonldPredicate:
         "_id": "sld:type"
         "_type": "@vocab"


### PR DESCRIPTION
This commit completes the transition started by the previous commit by including the `ExpressionToolOutputParameter`.